### PR TITLE
bsp: remove dependency on meta-marvell for espressobin

### DIFF
--- a/meta-ledge-bsp/conf/machine/ledge-espressobin.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-espressobin.conf
@@ -1,6 +1,6 @@
-require conf/machine/cb-88f3720-ddr3-espressobin.conf
+require conf/machine/include/arm/arch-arm64.inc
 
-MACHINEOVERRIDES .= ":cb-88f3720-ddr3-espressobin"
+MACHINE_ENDIANNESS ?= "le"
 
 PREFERRED_PROVIDER_virtual/kernel = "linux-ledge"
 PREFERRED_VERSION_linux-ledge = "mainline%"
@@ -11,4 +11,10 @@ PACKAGECONFIG_pn_mesa = "${@bb.utils.filter('DISTRO_FEATURES', 'wayland ', d)} \
                    ${@bb.utils.contains('DISTRO_FEATURES', 'x11 vulkan', 'dri3', '', d)} \
                    gallium"
 
+KERNEL_IMAGETYPE = "Image"
 KERNEL_DEVICETREE = "marvell/armada-3720-espressobin.dtb"
+
+SERIAL_CONSOLE = "115200 ttyMV0"
+ARM_TRUSTED_FIRMWARE_PLATFORM = "a3700"
+
+MACHINE_FEATURES = "ext2 ipsec nfs pci smbfs usbgadget usbhost vfat"

--- a/meta-ledge-bsp/recipes-kernel/linux/linux-ledge_mainline.bb
+++ b/meta-ledge-bsp/recipes-kernel/linux/linux-ledge_mainline.bb
@@ -26,7 +26,7 @@ KERNEL_CONFIG_COMMAND = "oe_runmake -C ${S} O=${B} ${KERNEL_DEFCONFIG}"
 SRC_URI_append = " file://fragment-02-systemd.config "
 SRC_URI_append = " file://fragment-10-ledge.config "
 
-COMPATIBLE_MACHINE = "(armada37xx|armada38x|armada70xx|armada80xx)"
+COMPATIBLE_MACHINE = "(ledge-espressobin)"
 
 do_configure() {
     touch ${B}/.scmversion ${S}/.scmversion


### PR DESCRIPTION
Remove machine files requirements from meta-marvell and add them directly
into our configuration

Signed-off-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>