### PR TITLE
bsp: add support for stm32mp157c-dk2

### DIFF
--- a/meta-ledge-bsp/conf/machine/ledge-stm32mp157c-dk2.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-stm32mp157c-dk2.conf
@@ -1,0 +1,22 @@
+include conf/machine/include/tune-cortexa7.inc
+
+DEFAULTTUNE = "cortexa7thf-neon-vfpv4"
+
+PREFERRED_PROVIDER_virtual/kernel = "linux-ledge"
+PREFERRED_VERSION_linux-ledge = "mainline%"
+
+PACKAGECONFIG_pn_mesa = "${@bb.utils.filter('DISTRO_FEATURES', 'wayland ', d)} \
+                   ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'opengl egl gles gbm dri', '', d)} \
+                   ${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', 'x11', '', d)} \
+                   ${@bb.utils.contains('DISTRO_FEATURES', 'x11 vulkan', 'dri3', '', d)} \
+                   \
+                   gallium \
+        "
+
+KERNEL_DEVICETREE = "stm32mp157c-ed1.dtb"
+SERIAL_CONSOLE = "115200 ttySTM0"
+
+MACHINE_FEATURES = "ext2 ipsec nfs pci smbfs usbgadget usbhost vfat"
+
+MACHINE_FEATURES += "tsn"
+MACHINE_FEATURES += "watchdog"

--- a/meta-ledge-sw/recipes-core/systemd/systemd-conf.bbappend
+++ b/meta-ledge-sw/recipes-core/systemd/systemd-conf.bbappend
@@ -1,0 +1,12 @@
+SUMMARY = "Enable systemd watchdog"
+FILESEXTRAPATH_prepend := "${THISDIR}/${PN}"
+
+do_install_append() {
+if ${@bb.utils.contains('MACHINE_FEATURES', 'watchdog', 'false', 'true', d)}; then
+    sed -i -e 's/.*RuntimeWatchdogSec.*/RuntimeWatchdogSec=30/' \
+        ${D}${sysconfdir}/systemd/system.conf
+
+    sed -i -e 's/.*ShutdownWatchdogSec.*/ShutdownWatchdogSec=5min/' \
+        ${D}${sysconfdir}/systemd/system.conf
+fi
+}


### PR DESCRIPTION
DTS file is set to stm32mp157c-ed1. Set the proper one once upstreamed on
mainline kernel

Signed-off-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>