### PR TITLE
bsp: Allow ledge-stm32mp157c-dk2 to use mainline kernel

### DIFF
--- a/meta-ledge-bsp/recipes-kernel/linux/linux-ledge_mainline.bb
+++ b/meta-ledge-bsp/recipes-kernel/linux/linux-ledge_mainline.bb
@@ -25,7 +25,7 @@ KERNEL_CONFIG_COMMAND = "oe_runmake -C ${S} O=${B} ${KERNEL_DEFCONFIG}"
 SRC_URI_append = " file://fragment-02-systemd.config "
 SRC_URI_append = " file://fragment-10-ledge.config "
 
-COMPATIBLE_MACHINE = "(ledge-espressobin)"
+COMPATIBLE_MACHINE = "(ledge-espressobin|ledge-stm32mp157c-dk2)"
 
 do_configure() {
     touch ${B}/.scmversion ${S}/.scmversion


### PR DESCRIPTION
Signed-off-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>