### PR TITLE
bsp: stm32mp157c-dk2: add default bootloader

### DIFF
--- a/meta-ledge-bsp/conf/machine/ledge-stm32mp157c-dk2.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-stm32mp157c-dk2.conf
@@ -20,3 +20,6 @@ MACHINE_FEATURES = "ext2 ipsec nfs pci smbfs usbgadget usbhost vfat"
 
 MACHINE_FEATURES += "tsn"
 MACHINE_FEATURES += "watchdog"
+
+PREFERRED_PROVIDER_virtual/bootloader = "u-boot"
+UBOOT_MACHINE = "stm32mp15_basic_defconfig"


### PR DESCRIPTION
Add a default bootloader provider and configuration to perform a full build.

Signed-off-by: Christophe Priouzeau <christophe.priouzeau@st.com>