### PR TITLE
make ledge-qemuarm work

### DIFF
--- a/meta-ledge-bsp/conf/machine/ledge-qemuarm.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-qemuarm.conf
@@ -14,9 +14,8 @@ SERIAL_CONSOLES ?= "115200;ttyAMA0 115200;ttyAMA1"
 
 # For runqemu
 QB_SYSTEM_NAME = "qemu-system-arm"
-QB_MACHINE = "-machine versatilepb"
+QB_MACHINE = "-machine virt"
 QB_KERNEL_CMDLINE_APPEND = "console=ttyAMA0,115200 console=tty"
-# Add the 'virtio-rng-pci' device otherwise the guest may run out of entropy
-QB_OPT_APPEND = "-show-cursor -usb -device usb-tablet -device virtio-rng-pci"
-PREFERRED_VERSION_linux-yocto ??= "4.18%"
-QB_DTB = "${@oe.utils.version_less_or_equal('PREFERRED_VERSION_linux-yocto', '4.7', '', 'zImage-versatile-pb.dtb', d)}"
+QB_NETWORK_DEVICE = "-device virtio-net-device,netdev=net0,mac=@MAC@"
+
+QB_ROOTFS_OPT = "-drive if=none,file=@ROOTFS@,id=hd0 -device virtio-blk-device,drive=hd0"


### PR DESCRIPTION
OE supports command "runqemu <machine> nographic" make it work
for ledge-qemuarm i.e. "runqemu ledge-qemuarm nographic".

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>

I.e. build and run sequence now is following:

DISTRO=rpb MACHINE=ledge-qemuarm source ./setup-environment
bitbake ledge-gateway
runqemu ledge-qemuarm nographic
( the latest command will run on x86 compiled kernel with rootfs under emulated arm virial machine.)