### PR TITLE
ledge-stm32mp157c-dk2: workaround gcc-8 build issue with tune flags

### DIFF
--- a/meta-ledge-bsp/conf/machine/ledge-stm32mp157c-dk2.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-stm32mp157c-dk2.conf
@@ -2,6 +2,8 @@ include conf/machine/include/tune-cortexa7.inc
 
 DEFAULTTUNE = "cortexa7thf-neon-vfpv4"
 
+TUNE_FEATURES_remove_armv7ve = "cortexa7"
+
 PREFERRED_PROVIDER_virtual/kernel = "linux-ledge"
 PREFERRED_VERSION_linux-ledge = "mainline%"
 


### PR DESCRIPTION
There are larger patches in OE-core master branch to fix
the build issues with armv7ve tune flags, instead we are adding a
workaround for now based on this patch:
https://patchwork.openembedded.org/patch/151191/

Signed-off-by: Vishal Bhoj <vishal.bhoj@linaro.org>