### PR TITLE
correct issue for generation of raw image

### DIFF
--- a/meta-ledge-bsp/classes/image_types-ledge-raw.bbclass
+++ b/meta-ledge-bsp/classes/image_types-ledge-raw.bbclass
@@ -13,7 +13,6 @@ do_image_ledgeraw[depends] += " \
         gptfdisk-native:do_populate_sysroot \
         dosfstools-native:do_populate_sysroot \
         coreutils-native:do_populate_sysroot \
-        virtual/kernel:do_deploy \
         virtual/bootloader:do_deploy \
         raw-tools-native:do_deploy \
         ledge-flashlayout:do_deploy \

--- a/meta-ledge-bsp/recipes-core/images/initramfs-ostree-image.bbappend
+++ b/meta-ledge-bsp/recipes-core/images/initramfs-ostree-image.bbappend
@@ -1,0 +1,2 @@
+# remove raw image generation for initramfs
+IMAGE_FSTYPES_remove = "ledgeraw"

--- a/meta-ledge-bsp/recipes-ledge/images/ledge-image-bootfs.bb
+++ b/meta-ledge-bsp/recipes-ledge/images/ledge-image-bootfs.bb
@@ -6,6 +6,7 @@ LICENSE = "MIT"
 inherit core-image
 
 IMAGE_FSTYPES_remove = "wic"
+IMAGE_FSTYPES_remove = "ledgeraw"
 
 IMAGE_NAME_SUFFIX = ".bootfs"
 


### PR DESCRIPTION
The raw image MUST be created only for rootfs and not for other images.