### PR TITLE
images: ledge-iot remove pkgconf

### DIFF
--- a/meta-ledge-sw/recipes-samples/packagegroups/packagegroup-ledge-iot.bb
+++ b/meta-ledge-sw/recipes-samples/packagegroups/packagegroup-ledge-iot.bb
@@ -67,7 +67,6 @@ RDEPENDS_packagegroup-ledge-iot = "\
 	libpcre2 \
 	pinentry \
 	packagegroup-security-tpm2 \
-	pkgconf \
 	policycoreutils \
 	polkit \
 	popt \
@@ -335,6 +334,7 @@ RDEPENDS_packagegroup-ledge-iot = "\
 #p11-kit-trust
 #passwd
 #pciutils-libs
+#pkgconf
 #pkgconf-m4
 #pkgconf-pkg-config
 #podman


### PR DESCRIPTION
currently breaks the build with:
Initialising tasks...ERROR: Multiple .bb files are due to be built which each
provide pkgconfig:
Disable it until we choose a proper provider for the package

Signed-off-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>