### PR TITLE
images: ledge-iot remove criu for armv8's

### DIFF
--- a/meta-ledge-sw/recipes-samples/packagegroups/packagegroup-ledge-iot.bb
+++ b/meta-ledge-sw/recipes-samples/packagegroups/packagegroup-ledge-iot.bb
@@ -22,7 +22,7 @@ RDEPENDS_packagegroup-ledge-iot = "\
 	coreutils \
 	cpio \
 	cracklib \
-	criu \
+	${@bb.utils.contains_any("TUNE_ARCH", [ "x86_64", "arm" ] , "criu", "", d)} \
 	cryptsetup \
 	curl \
 	diffutils \


### PR DESCRIPTION
criu does not currently build for armv8 platforms. Let's remove it until
it's compilation is fixed

Signed-off-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>