### PR TITLE
U-BOOT-LEDGE: stm32mp157c-dk2: add devicetree alignment with kernel 5.1

### DIFF
--- a/meta-ledge-bsp/recipes-bsp/u-boot/u-boot-ledge.bb
+++ b/meta-ledge-bsp/recipes-bsp/u-boot/u-boot-ledge.bb
@@ -17,6 +17,10 @@ SRC_URI_append_ledge-stm32mp157c-dk2 = " \
         file://ledge_stm32mp157c_dk2_trusted_defconfig \
     "
 
+SRC_URI_append_ledge-stm32mp157c-dk2 = " \
+        file://0001-Devicetree-align-with-kernel-5.1.patch \
+    "
+
 S = "${WORKDIR}/git"
 
 require recipes-bsp/u-boot/u-boot.inc


### PR DESCRIPTION
Signed-off-by: Christophe Priouzeau <christophe.priouzeau@st.com>