### PR TITLE
meta-ledge-sw: remove efivar custom versions

### DIFF
--- a/meta-ledge-sw/conf/layer.conf
+++ b/meta-ledge-sw/conf/layer.conf
@@ -12,8 +12,3 @@ BBFILE_PRIORITY_meta-ledge-sw = "9"
 # cause compatibility issues with other layers
 LAYERVERSION_meta-ledge-sw = "1"
 LAYERSERIES_COMPAT_meta-ledge-sw= "sumo thud"
-
-# Force version of efivar because rpb provides 0.30 on an overlay which
-# breaks efivar and efibootmgr build
-PREFERRED_VERSION_efivar-native = "0.36"
-PREFERRED_VERSION_efivar = "0.36"


### PR DESCRIPTION
Latest meta-rpb removes the fivar overlays for v0.30
Remove the custom 0.36 version from our local config and use whatever
oe-core offers

Signed-off-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>