### PR TITLE
images: ledge-iot remove duplicate coreutils entry

### DIFF
--- a/meta-ledge-sw/recipes-samples/images/ledge-iot.bb
+++ b/meta-ledge-sw/recipes-samples/images/ledge-iot.bb
@@ -7,6 +7,5 @@ SUMMARY = "Basic console image for LEDGE IoT"
 IMAGE_FEATURES += "package-management ssh-server-dropbear allow-empty-password"
 
 CORE_IMAGE_BASE_INSTALL += "\
-    coreutils \
     packagegroup-ledge-iot \
     "


### PR DESCRIPTION
coreutils is included in the iot packagegroup and the image file

Signed-off-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>