### PR TITLE
images: ledge-iot replace dropbear with openssh

### DIFF
--- a/meta-ledge-sw/recipes-samples/images/ledge-iot.bb
+++ b/meta-ledge-sw/recipes-samples/images/ledge-iot.bb
@@ -4,7 +4,7 @@ SUMMARY = "Basic console image for LEDGE IoT"
 
 # For development, use ssh-server-dropbear instead of ssh-server-openssh which
 # allow root login via ssh.
-IMAGE_FEATURES += "package-management ssh-server-dropbear allow-empty-password"
+IMAGE_FEATURES += "package-management ssh-server-openssh allow-empty-password"
 
 CORE_IMAGE_BASE_INSTALL += "\
     packagegroup-ledge-iot \

--- a/meta-ledge-sw/recipes-samples/packagegroups/packagegroup-ledge-iot.bb
+++ b/meta-ledge-sw/recipes-samples/packagegroups/packagegroup-ledge-iot.bb
@@ -93,7 +93,7 @@ RDEPENDS_packagegroup-ledge-iot = "\
 	parted \
 	pciutils \
 	pinentry \
-	packagegroup-core-ssh-dropbear \
+	packagegroup-core-ssh-openssh \
 	packagegroup-security-tpm2 \
 	packagegroup-core-selinux \
 	popt \


### PR DESCRIPTION
Since this is going for cloud deployements use the safer and better openSSH
instead of the dropbear implementation

Signed-off-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>