### PR TITLE
ledge-qemux86-64: enable ovmf build

### DIFF
--- a/meta-ledge-bsp/conf/machine/ledge-qemux86-64.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-qemux86-64.conf
@@ -33,6 +33,7 @@ XSERVER = "xserver-xorg \
 MACHINE_FEATURES += "x86 pci"
 
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS += "v86d"
+EXTRA_IMAGEDEPENDS += "ovmf"
 
 MACHINE_EXTRA_RRECOMMENDS = "kernel-module-snd-ens1370 kernel-module-snd-rawmidi"
 


### PR DESCRIPTION
Build for ledge-qemux86-64 will support ovmf files
compiled and efi linux boot support.
Run command needs to be extended for ovmf:
 runqemu ledge-qemux86-64 nographic ovmf \
	qemuparams="-m 4096" bootparams="selinux=0"

For quick test I see that kernel detects efifb:
[    0.000000] efi: EFI v2.60 by EDK II
[    0.000000] efi:  SMBIOS=0xbfe33000  ACPI=0xbfe5c000  ACPI 2.0=0xbfe5c014  MEMATTR=0xbf5e0698
[    2.108449] Registered efivars operations
[    2.620006] efifb: probing for efifb
[    2.620572] efifb: framebuffer at 0xc0000000, using 1876k, total 1875k
[    2.620813] efifb: mode is 800x600x32, linelength=3200, pages=1
[    2.621022] efifb: scrolling: redraw
[    2.621245] efifb: Truecolor: size=8:8:8:8, shift=24:16:8:0

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>