### PR TITLE
Revert "ledge-ti: add extra space"

### DIFF
--- a/meta-ledge-bsp/conf/machine/ledge-ti-am572x.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-ti-am572x.conf
@@ -30,5 +30,4 @@ KERNEL_EXTRA_ARGS_append_ledge-ti-am572x += "LOADADDR=${UBOOT_ENTRYPOINT}"
 RDEPENDS_${KERNEL_PACKAGE_NAME}-base_append_ledge-ti-am572x = " prueth-fw"
 FILES_${KERNEL_PACKAGE_NAME}-devicetree_append_ledge-ti-am572x += "/${KERNEL_IMAGEDEST}/*.itb"
 
-IMAGE_ROOTFS_EXTRA_SPACE = "20971520"
 IMAGE_FSTYPES_append = " ext4 "


### PR DESCRIPTION
This reverts commit 373cb7a3aacb040795ef3d5f9c366716b149d98d.
No need for extra space. Other deploy scripts can increase
size if needed.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>