### PR TITLE
Generate Raw image for different image name

### DIFF
--- a/meta-ledge-bsp/classes/image_types-ledge-raw.bbclass
+++ b/meta-ledge-bsp/classes/image_types-ledge-raw.bbclass
@@ -30,6 +30,10 @@ IMAGE_CMD_ledgeraw () {
         name=$(echo $f | sed "s/tsv\.template/${IMAGE_LINK_NAME}\.tsv/")
         sed "s/%%IMAGE%/${IMAGE_LINK_NAME}.ext4/" $f > $name
     done
+    for f in $(ls -1 *.fld);
+    do
+        sed -i "s/%%IMAGE%/${IMAGE_LINK_NAME}.ext4/" $f
+    done
 
     for f in ${LEDGE_RAW_FLASHLAYOUTS};
     do

--- a/meta-ledge-bsp/recipes-devtools/generate-raw-image/files/ledge-stm32mp157c-dk2/FlashLayout_sdcard_ledge-stm32mp157c-dk2-basic.fld
+++ b/meta-ledge-bsp/recipes-devtools/generate-raw-image/files/ledge-stm32mp157c-dk2/FlashLayout_sdcard_ledge-stm32mp157c-dk2-basic.fld
@@ -18,4 +18,4 @@ E	teeh	Binary	0x00284400	optee/tee-header_v2.stm32
 E	teed	Binary	0x002C4400	optee/tee-pageable_v2.stm32
 E	teex	Binary	0x00304400	optee/tee-pager_v2.stm32
 P	bootfs	FileSystem	0x00344400	ledge-image-bootfs-ledge-stm32mp157c-dk2.ext4
-P	rootfs	FileSystem	0x04344400	ledge-gateway-ledge-stm32mp157c-dk2.ext4
+P	rootfs	FileSystem	0x04344400	%%IMAGE%

--- a/meta-ledge-bsp/recipes-devtools/generate-raw-image/files/ledge-stm32mp157c-dk2/FlashLayout_sdcard_ledge-stm32mp157c-dk2-optee.fld
+++ b/meta-ledge-bsp/recipes-devtools/generate-raw-image/files/ledge-stm32mp157c-dk2/FlashLayout_sdcard_ledge-stm32mp157c-dk2-optee.fld
@@ -18,4 +18,4 @@ P	teeh	Binary	0x00284400	optee/tee-header_v2.stm32
 P	teed	Binary	0x002C4400	optee/tee-pageable_v2.stm32
 P	teex	Binary	0x00304400	optee/tee-pager_v2.stm32
 P	bootfs	System	0x00344400	ledge-image-bootfs-ledge-stm32mp157c-dk2.ext4
-P	rootfs	FileSystem	0x04344400	ledge-gateway-ledge-stm32mp157c-dk2.ext4
+P	rootfs	FileSystem	0x04344400	%%IMAGE%


### PR DESCRIPTION
With this tow commit, the name of image are set during the process of raw image generation by openembedded.
