### PR TITLE
bsdp: machines: move espressobin image to synquacer

### DIFF
--- a/meta-ledge-bsp/conf/machine/ledge-synquacer.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-synquacer.conf
@@ -12,12 +12,7 @@ PACKAGECONFIG_pn_mesa = "${@bb.utils.filter('DISTRO_FEATURES', 'wayland ', d)} \
                    gallium"
 
 KERNEL_IMAGETYPE = "Image"
-KERNEL_DEVICETREE = "marvell/armada-3720-espressobin.dtb"
 
 SERIAL_CONSOLE = "115200 ttyMV0"
-ARM_TRUSTED_FIRMWARE_PLATFORM = "a3700"
 
 MACHINE_FEATURES = "ext2 ipsec nfs pci smbfs usbgadget usbhost vfat"
-
-PREFERRED_PROVIDER_virtual/bootloader = "u-boot"
-UBOOT_MACHINE = "mvebu_espressobin-88f3720_defconfig"

--- a/meta-ledge-bsp/recipes-kernel/linux/linux-ledge_mainline.bb
+++ b/meta-ledge-bsp/recipes-kernel/linux/linux-ledge_mainline.bb
@@ -41,7 +41,7 @@ SRC_URI_append = " file://fragment-10-ledge.config "
 SRC_URI_append = " file://fragment-11-virtio.config "
 SRC_URI_append = " file://fragment-12-security.config "
 
-COMPATIBLE_MACHINE = "(ledge-espressobin|ledge-stm32mp157c-dk2|ledge-qemux86-64|ledge-qemuarm|ledge-qemuarm64|ledge-ti-am572x)"
+COMPATIBLE_MACHINE = "(ledge-synquacer|ledge-stm32mp157c-dk2|ledge-qemux86-64|ledge-qemuarm|ledge-qemuarm64|ledge-ti-am572x)"
 
 do_configure() {
     touch ${B}/.scmversion ${S}/.scmversion


### PR DESCRIPTION
Since marvell is not a member and we are not maintaining the espressobin image,
use it as a basis to produce synquacer images

Signed-off-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>