### PR TITLE
KERNEL: generate stripped kernel modules tarball

### DIFF
--- a/meta-ledge-bsp/recipes-kernel/linux/linux-ledge-common.inc
+++ b/meta-ledge-bsp/recipes-kernel/linux/linux-ledge-common.inc
@@ -95,3 +95,13 @@ python __anonymous () {
             d.appendVar('FILES_' + kname + '-image-' + typelower, ' /boot/efi/boot ')
 }
 FILES_${KERNEL_PACKAGE_NAME}-base += "${nonarch_base_libdir}/modules/${KERNEL_VERSION}/modules.builtin.modinfo "
+
+do_deploy_append() {
+	if [ ${MODULE_TARBALL_DEPLOY} = "1" ] && (grep -q -i -e '^CONFIG_MODULES=y$' .config); then
+		mkdir -p ${D}${root_prefix}/lib
+		tar -cvzf $deployDir/modules-stripped-${MODULE_TARBALL_NAME}.tgz -C ${WORKDIR}/package/${root_prefix} lib
+		ln -sf modules-stripped-${MODULE_TARBALL_NAME}.tgz $deployDir/modules-stripped-${MODULE_TARBALL_LINK_NAME}.tgz
+	fi
+
+}
+


### PR DESCRIPTION
The default modules tarball's containts unstripped kernel modules
and we need to have a set of module stripped.

Signed-off-by: Christophe Priouzeau <christophe.priouzeau@linaro.org>