### PR TITLE
Add lava image for IOT

### DIFF
--- a/meta-ledge-bsp/conf/machine/ledge-stm32mp157c-dk2.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-stm32mp157c-dk2.conf
@@ -48,8 +48,8 @@ LEDGE_BOOTFS_PACKAGES = " \
 # raw images
 IMAGE_CLASSES += " image_types-ledge-raw"
 IMAGE_FSTYPES_append = " ext4 ledgeraw"
-LEDGE_RAW_FLASHLAYOUTS ?= "FlashLayout_sdcard_ledge-stm32mp157c-dk2-basic.fld FlashLayout_sdcard_ledge-stm32mp157c-dk2-optee.fld"
-LEDGE_RAW_FLASHER_TSV ?= "FlashLayout_sdcard_ledge-stm32mp157c-dk2-basic.tsv.template FlashLayout_sdcard_ledge-stm32mp157c-dk2-optee.tsv.template"
+LEDGE_RAW_FLASHLAYOUTS ?= "FlashLayout_sdcard_ledge-stm32mp157c-dk2-optee.fld"
+LEDGE_RAW_FLASHER_TSV ?= "FlashLayout_sdcard_ledge-stm32mp157c-dk2-optee.tsv.template"
 
 EXTRA_IMAGEDEPENDS_append = " raw-tools-native ledge-flashlayout "
 

--- a/meta-ledge-sw/recipes-samples/images/ledge-iot-lava.bb
+++ b/meta-ledge-sw/recipes-samples/images/ledge-iot-lava.bb
@@ -1,0 +1,8 @@
+require ledge-iot.bb
+
+SUMMARY = "IOT image for LEDGE (for Lava test)"
+
+CORE_IMAGE_BASE_INSTALL += "\
+    ${@bb.utils.contains("MACHINE_FEATURES", "tpm2", "packagegroup-ledge-tpm-lava", "", d)} \
+    "
+

--- a/meta-ledge-sw/recipes-samples/images/ledge-iot.bb
+++ b/meta-ledge-sw/recipes-samples/images/ledge-iot.bb
@@ -8,4 +8,6 @@ IMAGE_FEATURES += "package-management ssh-server-openssh allow-empty-password"
 
 CORE_IMAGE_BASE_INSTALL += "\
     packagegroup-ledge-iot \
+    ${@bb.utils.contains("MACHINE_FEATURES", "optee", "packagegroup-ledge-optee", "", d)} \
+    ${@bb.utils.contains("MACHINE_FEATURES", "tsn", "packagegroup-ledge-tsn", "", d)} \
     "


### PR DESCRIPTION
IOT Image: 
- add lava image with dependencies for tpm test
- add tsn and optee support of iot image.
