### PR TITLE
Kernel update and update for debian purpose

### DIFF
--- a/meta-ledge-bsp/conf/machine/ledge-stm32mp157c-dk2.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-stm32mp157c-dk2.conf
@@ -35,15 +35,7 @@ UBOOT_CONFIG[basic]   = "ledge_stm32mp157c_dk2_basic_defconfig,,u-boot.img"
 UBOOT_CONFIG[trusted] = "ledge_stm32mp157c_dk2_trusted_defconfig,,u-boot.stm32"
 UBOOT_CONFIG[optee]   = "ledge_stm32mp157c_dk2_optee_defconfig,,u-boot.stm32"
 
-MACHINE_EXTRA_RRECOMMENDS += "optee-os ledge-image-bootfs arm-trusted-firmware-ledge"
-
-
-# Bootfs partition
-LEDGE_BOOTFS_PARTITION_SIZE ?= "65536"
-LEDGE_BOOTFS_PACKAGES = " \
-    kernel-image \
-    kernel-devicetree \
-"
+MACHINE_EXTRA_RRECOMMENDS += "optee-os arm-trusted-firmware-ledge"
 
 # raw images
 IMAGE_CLASSES += " image_types-ledge-raw"

--- a/meta-ledge-bsp/recipes-devtools/generate-raw-image/files/ledge-stm32mp157c-dk2/FlashLayout_sdcard_ledge-stm32mp157c-dk2-basic.fld.template
+++ b/meta-ledge-bsp/recipes-devtools/generate-raw-image/files/ledge-stm32mp157c-dk2/FlashLayout_sdcard_ledge-stm32mp157c-dk2-basic.fld.template
@@ -17,5 +17,4 @@ P	ssbl	Binary	0x00084400	u-boot-basic.img
 E	teeh	Binary	0x00284400	optee/tee-header_v2.stm32
 E	teed	Binary	0x002C4400	optee/tee-pageable_v2.stm32
 E	teex	Binary	0x00304400	optee/tee-pager_v2.stm32
-P	bootfs	FileSystem	0x00344400	%%BOOTFS%
-P	rootfs	FileSystem	0x04344400	%%IMAGE%
+P	rootfs	FileSystem	0x00344400	%%IMAGE%

--- a/meta-ledge-bsp/recipes-devtools/generate-raw-image/files/ledge-stm32mp157c-dk2/FlashLayout_sdcard_ledge-stm32mp157c-dk2-basic.tsv.template
+++ b/meta-ledge-bsp/recipes-devtools/generate-raw-image/files/ledge-stm32mp157c-dk2/FlashLayout_sdcard_ledge-stm32mp157c-dk2-basic.tsv.template
@@ -19,5 +19,5 @@ P	0x06	ssbl	Binary	mmc0	0x00084400	u-boot-basic.img
 P	0x0A	teeh	Binary	mmc0	0x00284400	optee/tee-header_v2.stm32
 P	0x0B	teed	Binary	mmc0	0x002C4400	optee/tee-pageable_v2.stm32
 P	0x0C	teex	Binary	mmc0	0x00304400	optee/tee-pager_v2.stm32
-P	0x21	bootfs	System	mmc0	0x00344400	%%BOOTFS%
-P	0x22	rootfs	FileSystem	mmc0	0x04344400	%%IMAGE%
+P	0x21	rootfs	System	mmc0	0x00344400	%%IMAGE%
+

--- a/meta-ledge-bsp/recipes-devtools/generate-raw-image/files/ledge-stm32mp157c-dk2/FlashLayout_sdcard_ledge-stm32mp157c-dk2-debian.fld
+++ b/meta-ledge-bsp/recipes-devtools/generate-raw-image/files/ledge-stm32mp157c-dk2/FlashLayout_sdcard_ledge-stm32mp157c-dk2-debian.fld
@@ -13,11 +13,12 @@
 #Opt	Name	Type	Offset	Binary
 URI		https://snapshots.linaro.org/components/ledge/oe/ledge-stm32mp157c-dk2/latest/rpb/
 MODULE	modules-stripped-ledge-stm32mp157c-dk2-for-debian.tar.gz
+KERNEL zImage-for-debian
+DTB stm32mp157c-dk2.dtb-for-debian
 P	fsbl1	Binary	0x00004400	spl/u-boot-spl.stm32-basic
 P	fsbl2	Binary	0x00044400	spl/u-boot-spl.stm32-basic
 P	ssbl	Binary	0x00084400	u-boot-basic.img
 E	teeh	Binary	0x00284400	optee/tee-header_v2.stm32
 E	teed	Binary	0x002C4400	optee/tee-pageable_v2.stm32
 E	teex	Binary	0x00304400	optee/tee-pager_v2.stm32
-P	bootfs	FileSystem	0x00344400	ledge-image-bootfs-ledge-stm32mp157c-dk2-for-debian.ext4
-P	rootfs	FileSystem	0x04344400	rootfs-linaro-buster-raw-unknown-*.tar.xz
+P	rootfs	System	0x00344400	rootfs-linaro-buster-raw-unknown-*.tar.xz

--- a/meta-ledge-bsp/recipes-devtools/generate-raw-image/files/ledge-stm32mp157c-dk2/FlashLayout_sdcard_ledge-stm32mp157c-dk2-debian.tsv.template
+++ b/meta-ledge-bsp/recipes-devtools/generate-raw-image/files/ledge-stm32mp157c-dk2/FlashLayout_sdcard_ledge-stm32mp157c-dk2-debian.tsv.template
@@ -19,5 +19,4 @@ P	0x06	ssbl	Binary	mmc0	0x00084400	u-boot-basic.img
 P	0x0A	teeh	Binary	mmc0	0x00284400	optee/tee-header_v2.stm32
 P	0x0B	teed	Binary	mmc0	0x002C4400	optee/tee-pageable_v2.stm32
 P	0x0C	teex	Binary	mmc0	0x00304400	optee/tee-pager_v2.stm32
-P	0x21	bootfs	System	mmc0	0x00344400	ledge-image-bootfs-ledge-stm32mp157c-dk2-for-debian.ext4
-P	0x22	rootfs	FileSystem	mmc0	0x04344400	%%IMAGE%
+P	0x21	rootfs	System	mmc0	0x00344400	%%IMAGE%

--- a/meta-ledge-bsp/recipes-devtools/generate-raw-image/files/ledge-stm32mp157c-dk2/FlashLayout_sdcard_ledge-stm32mp157c-dk2-optee.fld.template
+++ b/meta-ledge-bsp/recipes-devtools/generate-raw-image/files/ledge-stm32mp157c-dk2/FlashLayout_sdcard_ledge-stm32mp157c-dk2-optee.fld.template
@@ -17,5 +17,4 @@ P	ssbl	Binary	0x00084400	u-boot-trusted.stm32
 P	teeh	Binary	0x00284400	optee/tee-header_v2.stm32
 P	teed	Binary	0x002C4400	optee/tee-pageable_v2.stm32
 P	teex	Binary	0x00304400	optee/tee-pager_v2.stm32
-P	bootfs	System	0x00344400	%%BOOTFS%
-P	rootfs	FileSystem	0x04344400	%%IMAGE%
+P	rootfs	System	0x00344400	%%IMAGE%

--- a/meta-ledge-bsp/recipes-devtools/generate-raw-image/files/ledge-stm32mp157c-dk2/FlashLayout_sdcard_ledge-stm32mp157c-dk2-optee.tsv.template
+++ b/meta-ledge-bsp/recipes-devtools/generate-raw-image/files/ledge-stm32mp157c-dk2/FlashLayout_sdcard_ledge-stm32mp157c-dk2-optee.tsv.template
@@ -19,5 +19,4 @@ P	0x06	ssbl	Binary	mmc0	0x00084400	u-boot-trusted.stm32
 P	0x0A	teeh	Binary	mmc0	0x00284400	optee/tee-header_v2.stm32
 P	0x0B	teed	Binary	mmc0	0x002C4400	optee/tee-pageable_v2.stm32
 P	0x0C	teex	Binary	mmc0	0x00304400	optee/tee-pager_v2.stm32
-P	0x21	bootfs	System	mmc0	0x00344400	%%BOOTFS%
-P	0x22	rootfs	FileSystem	mmc0	0x04344400	%%IMAGE%
+P	0x21	rootfs	System	mmc0	0x00344400	%%IMAGE%

--- a/meta-ledge-bsp/recipes-kernel/linux/linux-ledge-common.inc
+++ b/meta-ledge-bsp/recipes-kernel/linux/linux-ledge-common.inc
@@ -103,13 +103,20 @@ python __anonymous () {
 }
 FILES_${KERNEL_PACKAGE_NAME}-base += "${nonarch_base_libdir}/modules/${KERNEL_VERSION}/modules.builtin.modinfo "
 
-
+# for debian purpose
 do_deploy_append() {
-       if [ ${MODULE_TARBALL_DEPLOY} = "1" ] && (grep -q -i -e '^CONFIG_MODULES=y$' .config); then
-               mkdir -p ${D}${root_prefix}/lib
-               tar -cvzf $deployDir/modules-stripped-${MODULE_TARBALL_NAME}.tgz -C ${WORKDIR}/package/${root_prefix} lib
-               ln -sf modules-stripped-${MODULE_TARBALL_NAME}.tgz $deployDir/modules-stripped-${MODULE_TARBALL_LINK_NAME}.tgz
-       fi
+    if [ ${MODULE_TARBALL_DEPLOY} = "1" ] && (grep -q -i -e '^CONFIG_MODULES=y$' .config); then
+        mkdir -p ${D}${root_prefix}/lib
+        tar -cvzf $deployDir/modules-stripped-${MODULE_TARBALL_NAME}.tgz -C ${WORKDIR}/package/${root_prefix} lib
+        ln -sf modules-stripped-${MODULE_TARBALL_NAME}.tgz $deployDir/modules-stripped-${MODULE_TARBALL_LINK_NAME}.tgz
+    fi
 
+    for t in ${KERNEL_IMAGETYPE} ${KERNEL_ALT_IMAGETYPE}; do
+        cp -f $deployDir/$t $deployDir/$t-for-debian
+    done
+
+    for d in  ${KERNEL_DEVICETREE}; do
+        cp -f $deployDir/$d $deployDir/$d-for-debian
+    done
 }
 do_deploy[depends] += " virtual/kernel:do_package "

--- a/meta-ledge-bsp/recipes-kernel/linux/linux-ledge/0001-STM32mp157c-dk2-optee-and-ethernet-support.patch
+++ b/meta-ledge-bsp/recipes-kernel/linux/linux-ledge/0001-STM32mp157c-dk2-optee-and-ethernet-support.patch
@@ -1,49 +1,35 @@
-From e58b6a34b7e164f432a7a2f5b7afc9b48c5d21c9 Mon Sep 17 00:00:00 2001
+From 51efe87f6ed3aa0f485317e2db9b6ef45f91414a Mon Sep 17 00:00:00 2001
 From: Christophe Priouzeau <christophe.priouzeau@linaro.org>
-Date: Mon, 8 Jul 2019 17:55:18 +0200
-Subject: [PATCH] STM32mp157c-dk2: optee and ethernet support
+Date: Wed, 16 Oct 2019 12:02:35 +0200
+Subject: [PATCH 1/3] STM32mp157c-dk2: optee and ethernet support
 
 Signed-off-by: Christophe Priouzeau <christophe.priouzeau@linaro.org>
 ---
- arch/arm/boot/dts/stm32mp157a-dk1.dts | 12 +++++++++++-
- arch/arm/boot/dts/stm32mp157c.dtsi    |  8 ++++++++
- 2 files changed, 19 insertions(+), 1 deletion(-)
+ arch/arm/boot/dts/stm32mp157a-dk1.dts | 5 +++++
+ arch/arm/boot/dts/stm32mp157c.dtsi    | 7 +++++++
+ 2 files changed, 12 insertions(+)
 
 diff --git a/arch/arm/boot/dts/stm32mp157a-dk1.dts b/arch/arm/boot/dts/stm32mp157a-dk1.dts
-index 098dbfb06..dfedf738d 100644
+index f3f0e37aa..7751099a9 100644
 --- a/arch/arm/boot/dts/stm32mp157a-dk1.dts
 +++ b/arch/arm/boot/dts/stm32mp157a-dk1.dts
-@@ -27,6 +27,16 @@
- 	memory@c0000000 {
- 		reg = <0xc0000000 0x20000000>;
- 	};
-+	reserved-memory {
-+		#address-cells = <1>;
-+		#size-cells = <1>;
-+		ranges;
+@@ -37,6 +37,11 @@
+ 			reg = <0xd4000000 0x4000000>;
+ 			no-map;
+ 		};
 +
 +		optee_reserved: optee@dc000000 {
 +			reg = <0xde000000 0x02000000>;
 +			no-map;
 +		};
-+	};
+ 	};
  
  	led {
- 		compatible = "gpio-leds";
-@@ -51,7 +61,7 @@
- 	pinctrl-0 = <&ethernet0_rgmii_pins_a>;
- 	pinctrl-1 = <&ethernet0_rgmii_pins_sleep_a>;
- 	pinctrl-names = "default", "sleep";
--	phy-mode = "rgmii";
-+	phy-mode = "rgmii-id";
- 	max-speed = <1000>;
- 	phy-handle = <&phy0>;
- 
 diff --git a/arch/arm/boot/dts/stm32mp157c.dtsi b/arch/arm/boot/dts/stm32mp157c.dtsi
-index 2afeee65c..2808eb7ac 100644
+index 0c4e6ebc3..abb762f7f 100644
 --- a/arch/arm/boot/dts/stm32mp157c.dtsi
 +++ b/arch/arm/boot/dts/stm32mp157c.dtsi
-@@ -1268,4 +1268,12 @@
+@@ -1448,4 +1448,11 @@
  			status = "disabled";
  		};
  	};
@@ -54,7 +40,6 @@ index 2afeee65c..2808eb7ac 100644
 +			method = "smc";
 +		};
 +	};
-+
  };
 -- 
 2.17.1

--- a/meta-ledge-bsp/recipes-kernel/linux/linux-ledge/0002-ftpm.patch
+++ b/meta-ledge-bsp/recipes-kernel/linux/linux-ledge/0002-ftpm.patch
@@ -1,3 +1,8 @@
+From bd13f9cbff186a62ddd255d94144724ec98a66ba Mon Sep 17 00:00:00 2001
+From: Christophe Priouzeau <christophe.priouzeau@linaro.org>
+Date: Wed, 16 Oct 2019 12:03:40 +0200
+Subject: [PATCH 2/3] ftpm
+
 This patch adds support for a software-only implementation of a TPM
 running in TEE.
 
@@ -7,7 +12,6 @@ https://www.microsoft.com/en-us/research/publication/ftpm-software-implementatio
 As well as reference code for the firmware available here:
 https://github.com/Microsoft/ms-tpm-20-ref/tree/master/Samples/ARM32-FirmwareTPM
 
-Tested-by: Thirupathaiah Annapureddy <thiruan@microsoft.com>
 Signed-off-by: Thirupathaiah Annapureddy <thiruan@microsoft.com>
 Co-authored-by: Sasha Levin <sashal@kernel.org>
 Signed-off-by: Sasha Levin <sashal@kernel.org>
@@ -21,7 +25,7 @@ Signed-off-by: Sasha Levin <sashal@kernel.org>
  create mode 100644 drivers/char/tpm/tpm_ftpm_tee.h
 
 diff --git a/drivers/char/tpm/Kconfig b/drivers/char/tpm/Kconfig
-index 88a3c06fc153..17bfbf9f572f 100644
+index 88a3c06fc..17bfbf9f5 100644
 --- a/drivers/char/tpm/Kconfig
 +++ b/drivers/char/tpm/Kconfig
 @@ -164,6 +164,11 @@ config TCG_VTPM_PROXY
@@ -37,7 +41,7 @@ index 88a3c06fc153..17bfbf9f572f 100644
  source "drivers/char/tpm/st33zp24/Kconfig"
  endif # TCG_TPM
 diff --git a/drivers/char/tpm/Makefile b/drivers/char/tpm/Makefile
-index a01c4cab902a..c354cdff9c62 100644
+index a01c4cab9..c354cdff9 100644
 --- a/drivers/char/tpm/Makefile
 +++ b/drivers/char/tpm/Makefile
 @@ -33,3 +33,4 @@ obj-$(CONFIG_TCG_TIS_ST33ZP24) += st33zp24/
@@ -47,7 +51,7 @@ index a01c4cab902a..c354cdff9c62 100644
 +obj-$(CONFIG_TCG_FTPM_TEE) += tpm_ftpm_tee.o
 diff --git a/drivers/char/tpm/tpm_ftpm_tee.c b/drivers/char/tpm/tpm_ftpm_tee.c
 new file mode 100644
-index 000000000000..74766a4d3280
+index 000000000..74766a4d3
 --- /dev/null
 +++ b/drivers/char/tpm/tpm_ftpm_tee.c
 @@ -0,0 +1,350 @@
@@ -403,7 +407,7 @@ index 000000000000..74766a4d3280
 +MODULE_LICENSE("GPL v2");
 diff --git a/drivers/char/tpm/tpm_ftpm_tee.h b/drivers/char/tpm/tpm_ftpm_tee.h
 new file mode 100644
-index 000000000000..f98daa7bf68c
+index 000000000..f98daa7bf
 --- /dev/null
 +++ b/drivers/char/tpm/tpm_ftpm_tee.h
 @@ -0,0 +1,40 @@
@@ -448,5 +452,5 @@ index 000000000000..f98daa7bf68c
 +
 +#endif /* __TPM_FTPM_TEE_H__ */
 -- 
-2.20.1
+2.17.1
 

--- a/meta-ledge-bsp/recipes-kernel/linux/linux-ledge/0003-KERNEL-stm32mp157-dts-add-ftpm-support.patch
+++ b/meta-ledge-bsp/recipes-kernel/linux/linux-ledge/0003-KERNEL-stm32mp157-dts-add-ftpm-support.patch
@@ -1,21 +1,22 @@
-From 042d362bb0ec7942247ab848dd573d51aaff45da Mon Sep 17 00:00:00 2001
+From 14e0cb4fdb86d0044f39aeba110f2f6daa52c4ef Mon Sep 17 00:00:00 2001
 From: Christophe Priouzeau <christophe.priouzeau@linaro.org>
-Date: Thu, 18 Jul 2019 09:02:30 +0200
-Subject: [PATCH] KERNEL: stm32mp157: dts; add ftpm support
+Date: Wed, 16 Oct 2019 12:05:38 +0200
+Subject: [PATCH 3/3] KERNEL: stm32mp157: dts; add ftpm support
 
 Signed-off-by: Christophe Priouzeau <christophe.priouzeau@linaro.org>
 ---
- arch/arm/boot/dts/stm32mp157a-dk1.dts | 7 +++++++
- 1 file changed, 7 insertions(+)
+ arch/arm/boot/dts/stm32mp157a-dk1.dts | 8 ++++++++
+ 1 file changed, 8 insertions(+)
 
 diff --git a/arch/arm/boot/dts/stm32mp157a-dk1.dts b/arch/arm/boot/dts/stm32mp157a-dk1.dts
-index dfedf738d..55b347ac1 100644
+index 7751099a9..f9819606a 100644
 --- a/arch/arm/boot/dts/stm32mp157a-dk1.dts
 +++ b/arch/arm/boot/dts/stm32mp157a-dk1.dts
-@@ -47,6 +47,13 @@
+@@ -53,6 +53,14 @@
  			default-state = "off";
  		};
  	};
++
 +	soc {
 +		tpm@0 {
 +			compatible = "microsoft,ftpm";

--- a/meta-ledge-bsp/recipes-kernel/linux/linux-ledge_mainline.bb
+++ b/meta-ledge-bsp/recipes-kernel/linux/linux-ledge_mainline.bb
@@ -8,25 +8,28 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=bbea815ee2795b2f4230826c0c6b8814"
 
 include linux-ledge-common.inc
 
-LEDGE_KVERSION = "5.2"
+LEDGE_KVERSION = "5.3.6"
 
 # Stable kernel URL
 SRC_URI = "https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-${LEDGE_KVERSION}.tar.xz;name=kernel"
 
-SRC_URI[kernel.md5sum] = "ddf994de00d7b18395886dd9b30b9262"
-SRC_URI[kernel.sha256sum] = "54ad66f672e1a831b574f5e704e8a05f1e6180a8245d4bdd811208a6cb0ac1e7"
+SRC_URI[kernel.md5sum] = "9905ef7f60b2ad0b26f614d95f3eb1e4"
+SRC_URI[kernel.sha256sum] = "e84021a94784de7bb10e4251fb1a87859a8d1c97bd78fb55ad47ab6ce475ec1f"
+
 # force SOURCE_DATE_EPOCH for build reproductible
 # SOURCE_DATE_EPOCH = "1557103378"
 
 # RC kernel URL
 #SRC_URI = "https://git.kernel.org/torvalds/t/linux-${LEDGE_KVERSION}.tar.gz;name=kernel"
 
-SRC_URI_append_ledge-stm32mp157c-dk2 = " file://0001-STM32mp157c-dk2-optee-and-ethernet-support.patch "
-SRC_URI_append_ledge-stm32mp157c-dk2 = " file://0002-ftpm.patch "
-SRC_URI_append_ledge-stm32mp157c-dk2 = " file://0001-KERNEL-stm32mp157-dts-add-ftpm-support.patch "
+SRC_URI += " \
+    file://0001-STM32mp157c-dk2-optee-and-ethernet-support.patch \
+    file://0002-ftpm.patch \
+    file://0003-KERNEL-stm32mp157-dts-add-ftpm-support.patch \
+    "
 
-PV = "mainline-5.2"
-S = "${WORKDIR}/linux-5.2"
+PV = "mainline-5.3"
+S = "${WORKDIR}/linux-5.3.6"
 
 COMPATIBLE_MACHINE = "(ledge-synquacer|ledge-stm32mp157c-dk2|ledge-qemux86-64|ledge-qemuarm|ledge-qemuarm64|ledge-ti-am572x)"
 


### PR DESCRIPTION
Kernel: 
- bump to kernel 5.3
- deploy kernel and devicetree for debian purpose
Machine: 
- remove usage of bootfs
Flashlayout:
- update flashlayout for removing bootfs
Debian:
- update script to add kernel and devicetree on rootfs

- 