### PR TITLE
ledge-qemuarm64: fix building u-boot

### DIFF
--- a/meta-ledge-bsp/conf/machine/ledge-qemuarm64.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-qemuarm64.conf
@@ -21,7 +21,7 @@ PREFERRED_PROVIDER_virtual/bootloader = "u-boot-ledge-qemu"
 UBOOT_CONFIG = "basic"
 UBOOT_DEVICETREE = "qemu_arm64.dtb"
 UBOOT_CONFIG[basic]   = "qemu_arm64_defconfig,,u-boot.bin"
-
+EXTRA_IMAGEDEPENDS_append = " virtual/bootloader"
 
 # For runqemu
 QB_SYSTEM_NAME = "qemu-system-aarch64"

--- a/meta-ledge-bsp/recipes-bsp/u-boot/u-boot-ledge-qemu.bb
+++ b/meta-ledge-bsp/recipes-bsp/u-boot/u-boot-ledge-qemu.bb
@@ -11,10 +11,12 @@ PE = "1"
 # repo during parse
 SRCREV = "cdbde65166dd9936d52c6acdc8e38cf685f82195"
 
-SRC_URI = "git://git.linaro.org/people/takahiro.akashi/u-boot.git"
+SRC_URI = "git://git.linaro.org/people/takahiro.akashi/u-boot.git;branch=efi/secboot"
 
 S = "${WORKDIR}/git"
 
 require recipes-bsp/u-boot/u-boot.inc
 
 DEPENDS += "bc-native dtc-native"
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+COMPATIBLE_MACHINE = "(ledge-qemuarm64)"


### PR DESCRIPTION
We need to specify branch name for correct u-boot builing
and add build to the image.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>