### PR TITLE
packagegroup-ledge-iot.bb: drop cryptsetup

### DIFF
--- a/meta-ledge-sw/recipes-samples/packagegroups/packagegroup-ledge-iot.bb
+++ b/meta-ledge-sw/recipes-samples/packagegroups/packagegroup-ledge-iot.bb
@@ -23,7 +23,6 @@ RDEPENDS_packagegroup-ledge-iot = "\
 	cpio \
 	cracklib \
 	${@bb.utils.contains_any("TUNE_ARCH", [ "x86_64", "arm" ] , "criu", "", d)} \
-	cryptsetup \
 	curl \
 	diffutils \
 	dnf \


### PR DESCRIPTION
cryptsetup  conflicts with cryptsetup-tpm-incubator,
removing it.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>