### PR TITLE
wic: use gpt label to mount rootfs

### DIFF
--- a/meta-ledge-bsp/recipes-kernel/linux/linux-ledge-common.inc
+++ b/meta-ledge-bsp/recipes-kernel/linux/linux-ledge-common.inc
@@ -8,6 +8,7 @@ KERNEL_CONFIG_FRAGMENTS_append = " ${WORKDIR}/fragment-02-systemd.config "
 KERNEL_CONFIG_FRAGMENTS_append = " ${WORKDIR}/fragment-10-ledge.config "
 KERNEL_CONFIG_FRAGMENTS_append = " ${WORKDIR}/fragment-11-virtio.config "
 KERNEL_CONFIG_FRAGMENTS_append = " ${WORKDIR}/fragment-12-security.config "
+KERNEL_CONFIG_FRAGMENTS_append = " ${WORKDIR}/fragment-13-cmdline.config "
 KERNEL_CONFIG_COMMAND = "oe_runmake -C ${S} O=${B} ${KERNEL_DEFCONFIG}"
 
 SRC_URI_append = " file://fragment-01-core.config "
@@ -15,6 +16,7 @@ SRC_URI_append = " file://fragment-02-systemd.config "
 SRC_URI_append = " file://fragment-10-ledge.config "
 SRC_URI_append = " file://fragment-11-virtio.config "
 SRC_URI_append = " file://fragment-12-security.config "
+SRC_URI_APPEND = " file://fragment-13-cmdline.config "
 
 do_configure() {
     touch ${B}/.scmversion ${S}/.scmversion

--- a/meta-ledge-bsp/recipes-kernel/linux/linux-ledge/fragment-13-cmdline.config
+++ b/meta-ledge-bsp/recipes-kernel/linux/linux-ledge/fragment-13-cmdline.config
@@ -1,0 +1,2 @@
+# cmdline
+CONFIG_CMDLINE="root=PARTLABEL=rootfs"

--- a/meta-ledge-bsp/wic/ledge-kernel-uefi.wks.in
+++ b/meta-ledge-bsp/wic/ledge-kernel-uefi.wks.in
@@ -1,2 +1,3 @@
+bootloader  --ptable gpt --timeout=0  --append="rootwait"
 part /boot --source rootfs --rootfs-dir=${IMAGE_ROOTFS}/boot --fstype=vfat --label bootfs --active --align 1024 --fixed-size 128M --use-uuid
-part / --source rootfs --fstype=ext4 --label rootfs --align 1024 --exclude-path boot/
+part / --source rootfs --fstype=ext4 --label rootfs --align 1024 --exclude-path boot/ --use-label


### PR DESCRIPTION
place gpt table inside image and mark root partition with
label rootfs. Kernel mounts that partition with
root=PARTLABEL=rootfs option.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>