### PR TITLE
recipes-kernel: fix _APPEND typo

### DIFF
--- a/meta-ledge-bsp/recipes-kernel/linux/linux-ledge-common.inc
+++ b/meta-ledge-bsp/recipes-kernel/linux/linux-ledge-common.inc
@@ -16,7 +16,7 @@ SRC_URI_append = " file://fragment-02-systemd.config "
 SRC_URI_append = " file://fragment-10-ledge.config "
 SRC_URI_append = " file://fragment-11-virtio.config "
 SRC_URI_append = " file://fragment-12-security.config "
-SRC_URI_APPEND = " file://fragment-13-cmdline.config "
+SRC_URI_append = " file://fragment-13-cmdline.config "
 
 do_configure() {
     touch ${B}/.scmversion ${S}/.scmversion


### PR DESCRIPTION
Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>