### PR TITLE
ledge: fix ledge-iot build with commenting out cryptsetup-tpm-incubator

### DIFF
--- a/meta-ledge-sw/conf/layer.conf
+++ b/meta-ledge-sw/conf/layer.conf
@@ -6,7 +6,7 @@ BBFILES += "${LAYERDIR}/recipes*/*/*.bb ${LAYERDIR}/recipes*/*/*.bbappend"
 
 BBFILE_COLLECTIONS += "meta-ledge-sw"
 BBFILE_PATTERN_meta-ledge-sw := "^${LAYERDIR}/"
-BBFILE_PRIORITY_meta-ledge-sw = "9"
+BBFILE_PRIORITY_meta-ledge-sw = "30"
 
 # This should only be incremented on significant changes that will
 # cause compatibility issues with other layers

--- a/meta-ledge-sw/recipes-samples/images/ledge-iot.bb
+++ b/meta-ledge-sw/recipes-samples/images/ledge-iot.bb
@@ -10,4 +10,5 @@ CORE_IMAGE_BASE_INSTALL += "\
     packagegroup-ledge-iot \
     ${@bb.utils.contains("MACHINE_FEATURES", "optee", "packagegroup-ledge-optee", "", d)} \
     ${@bb.utils.contains("MACHINE_FEATURES", "tsn", "packagegroup-ledge-tsn", "", d)} \
+    ${@bb.utils.contains("MACHINE_FEATURES", "tpm2", "packagegroup-security-tpm2", "", d)} \
     "

--- a/meta-ledge-sw/recipes-samples/packagegroups/packagegroup-ledge-iot.bb
+++ b/meta-ledge-sw/recipes-samples/packagegroups/packagegroup-ledge-iot.bb
@@ -94,7 +94,6 @@ RDEPENDS_packagegroup-ledge-iot = "\
 	pciutils \
 	pinentry \
 	packagegroup-core-ssh-openssh \
-	${@bb.utils.contains("MACHINE_FEATURES", "tpm2", "packagegroup-security-tpm2", "", d)} \
 	packagegroup-core-selinux \
 	popt \
 	procps \

--- a/meta-ledge-sw/recipes-samples/packagegroups/packagegroup-security-tpm2.bbappend
+++ b/meta-ledge-sw/recipes-samples/packagegroups/packagegroup-security-tpm2.bbappend
@@ -1,0 +1,7 @@
+# cryptsetup in zeus branch has higher version then
+# cryptsetup-tpm-incubator that leads to not replacement
+# of package. Remove it from build for now.
+#
+RDEPENDS_packagegroup-security-tpm2_remove = " \
+    cryptsetup-tpm-incubator \
+    "


### PR DESCRIPTION
1. meta-securuty in zeus has more priority then meta-ledge. Fixing it.
2. cryptsetup-tpm-incubator should replace cyptsetup but it has lower
 version number. Comment it out for now to make ledge-iot image build.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>