### PR TITLE
ledge: kernel: add patches for fTPM and shm usage

### DIFF
--- a/meta-ledge-bsp/recipes-kernel/linux/linux-ledge/0004-op-tee-shm.patch
+++ b/meta-ledge-bsp/recipes-kernel/linux/linux-ledge/0004-op-tee-shm.patch
@@ -1,0 +1,55 @@
+diff --git a/drivers/tee/optee/call.c b/drivers/tee/optee/call.c
+index 13b0269..cf2367b 100644
+--- a/drivers/tee/optee/call.c
++++ b/drivers/tee/optee/call.c
+@@ -554,6 +554,13 @@ static int check_mem_type(unsigned long start, size_t num_pages)
+	struct mm_struct *mm = current->mm;
+	int rc;
+
++	/*
++	 * Allow kernel address to register with OP-TEE as kernel
++	 * pages are configured as normal memory only.
++	 */
++	if (virt_addr_valid(start))
++		return 0;
++
+	down_read(&mm->mmap_sem);
+	rc = __check_mem_type(find_vma(mm, start),
+				start + num_pages * PAGE_SIZE);
+diff --git a/drivers/tee/optee/shm_pool.c b/drivers/tee/optee/shm_pool.c
+index de1d9b8..0332a53 100644
+--- a/drivers/tee/optee/shm_pool.c
++++ b/drivers/tee/optee/shm_pool.c
+@@ -17,6 +17,7 @@ static int pool_op_alloc(struct tee_shm_pool_mgr *poolm,
+ {
+	unsigned int order = get_order(size);
+	struct page *page;
++	int rc = 0;
+
+	page = alloc_pages(GFP_KERNEL | __GFP_ZERO, order);
+	if (!page)
+@@ -26,12 +27,21 @@ static int pool_op_alloc(struct tee_shm_pool_mgr *poolm,
+	shm->paddr = page_to_phys(page);
+	shm->size = PAGE_SIZE << order;
+
+-	return 0;
++	if (shm->flags & TEE_SHM_DMA_BUF) {
++		shm->flags |= TEE_SHM_REGISTER;
++		rc = optee_shm_register(shm->ctx, shm, &page, 1 << order,
++								(unsigned long)shm->kaddr);
++	}
++
++	return rc;
+ }
+
+ static void pool_op_free(struct tee_shm_pool_mgr *poolm,
+			 struct tee_shm *shm)
+ {
++	if (shm->flags & TEE_SHM_DMA_BUF)
++		optee_shm_unregister(shm->ctx, shm);
++
+	free_pages((unsigned long)shm->kaddr, get_order(shm->size));
+	shm->kaddr = NULL;
+ }
+--
+2.7.4

--- a/meta-ledge-bsp/recipes-kernel/linux/linux-ledge/0005-op-tee-multi-page-shm.patch
+++ b/meta-ledge-bsp/recipes-kernel/linux/linux-ledge/0005-op-tee-multi-page-shm.patch
@@ -1,0 +1,28 @@
+diff --git a/drivers/tee/optee/shm_pool.c b/drivers/tee/optee/shm_pool.c
+index 0332a53..85aa5bb 100644
+--- a/drivers/tee/optee/shm_pool.c
++++ b/drivers/tee/optee/shm_pool.c
+@@ -28,8 +28,20 @@ static int pool_op_alloc(struct tee_shm_pool_mgr *poolm,
+	shm->size = PAGE_SIZE << order;
+
+	if (shm->flags & TEE_SHM_DMA_BUF) {
++		unsigned int nr_pages = 1 << order, i;
++		struct page **pages;
++
++		pages = kcalloc(nr_pages, sizeof(pages), GFP_KERNEL);
++		if (!pages)
++			return -ENOMEM;
++
++		for (i = 0; i < nr_pages; i++) {
++			pages[i] = page;
++			page++;
++		}
++
+		shm->flags |= TEE_SHM_REGISTER;
+-		rc = optee_shm_register(shm->ctx, shm, &page, 1 << order,
++		rc = optee_shm_register(shm->ctx, shm, pages, nr_pages,
+								(unsigned long)shm->kaddr);
+	}
+
+--
+2.7.4

--- a/meta-ledge-bsp/recipes-kernel/linux/linux-ledge_mainline.bb
+++ b/meta-ledge-bsp/recipes-kernel/linux/linux-ledge_mainline.bb
@@ -26,6 +26,8 @@ SRC_URI += " \
     file://0001-STM32mp157c-dk2-optee-and-ethernet-support.patch \
     file://0002-ftpm.patch \
     file://0003-KERNEL-stm32mp157-dts-add-ftpm-support.patch \
+    file://0004-op-tee-shm.patch \
+    file://0005-op-tee-multi-page-shm.patch \
     "
 
 PV = "mainline-5.3"


### PR DESCRIPTION
A hack was needed for fTPM + QEMU as reported here
https://lkml.org/lkml/2019/7/3/60
Pick up patches that have not been applied to our current kernel

Signed-off-by: Ilias Apalodimas ilias.apalodimas@linaro.org