### PR TITLE
qemu: change u-boot boot command

### DIFF
--- a/meta-ledge-bsp/recipes-bsp/u-boot/u-boot-ledge-qemu/ledge-qemuarm64_defconfig
+++ b/meta-ledge-bsp/recipes-bsp/u-boot/u-boot-ledge-qemu/ledge-qemuarm64_defconfig
@@ -241,7 +241,7 @@ CONFIG_BOOTSTAGE_STASH_SIZE=0x1000
 CONFIG_BOOTDELAY=2
 # CONFIG_USE_BOOTARGS is not set
 CONFIG_USE_BOOTCOMMAND=y
-CONFIG_BOOTCOMMAND="setenv bootargs 'selinux=0 rootwait root=PARTLABEL=rootfs'; fatload virtio 0:1 $kernel_addr_r efi/boot/Image; bootefi $kernel_addr_r $fdtcontroladdr"
+CONFIG_BOOTCOMMAND="setenv kernel_addr_r 0x60000000; setenv bootargs 'rootwait root=PARTLABEL=rootfs'; efidebug boot add 0000 'kernel' virtio 0:1 /efi/boot/bootaa64.efi; efidebug boot order 0000; bootefi bootmgr"
 CONFIG_USE_PREBOOT=y
 CONFIG_PREBOOT="pci enum"
 
@@ -498,7 +498,7 @@ CONFIG_CMD_PXE=y
 CONFIG_CMD_BLOCK_CACHE=y
 # CONFIG_CMD_CACHE is not set
 # CONFIG_CMD_CONITRACE is not set
-# CONFIG_CMD_EFIDEBUG is not set
+CONFIG_CMD_EFIDEBUG=y
 # CONFIG_CMD_EXCEPTION is not set
 CONFIG_CMD_DATE=y
 # CONFIG_CMD_TIME is not set

--- a/meta-ledge-bsp/recipes-bsp/u-boot/u-boot-ledge-qemu/ledge-qemuarm_defconfig
+++ b/meta-ledge-bsp/recipes-bsp/u-boot/u-boot-ledge-qemu/ledge-qemuarm_defconfig
@@ -232,7 +232,7 @@ CONFIG_BOOTSTAGE_STASH_SIZE=0x1000
 CONFIG_BOOTDELAY=2
 # CONFIG_USE_BOOTARGS is not set
 CONFIG_USE_BOOTCOMMAND=y
-CONFIG_BOOTCOMMAND="setenv bootargs 'rootwait root=PARTLABEL=rootfs'; fatload virtio 0:1 $kernel_addr_r efi/boot/Image; bootefi $kernel_addr_r $fdtcontroladdr"
+CONFIG_BOOTCOMMAND="setenv kernel_addr_r 0x60000000; setenv bootargs 'rootwait root=PARTLABEL=rootfs'; efidebug boot add 0000 'kernel' virtio 0:1 /efi/boot/bootarm.efi; efidebug boot order 0000; bootefi bootmgr"
 CONFIG_USE_PREBOOT=y
 CONFIG_PREBOOT="pci enum"
 
@@ -495,7 +495,7 @@ CONFIG_CMD_PXE=y
 CONFIG_CMD_BLOCK_CACHE=y
 # CONFIG_CMD_CACHE is not set
 # CONFIG_CMD_CONITRACE is not set
-# CONFIG_CMD_EFIDEBUG is not set
+CONFIG_CMD_EFIDEBUG=y
 # CONFIG_CMD_EXCEPTION is not set
 CONFIG_CMD_DATE=y
 # CONFIG_CMD_TIME is not set


### PR DESCRIPTION
U-boot grew in size with the TF-A and efidebug additions. Change the kernel
load address to account for that.
In addition use bootefi bootmgr and set BootOrderXXX variable correctly
since we move towards a full UEFI compliant boot.

Signed-off-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>