### PR TITLE
tf-a: Fix aarch64 builds for OP-TEE

### DIFF
--- a/meta-ledge-bsp/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware-ledge_git.bb
+++ b/meta-ledge-bsp/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware-ledge_git.bb
@@ -48,8 +48,9 @@ TF_A_CONFIG_ledge-qemuarm64 = "qemu_arm64_defconfig"
 #PACKAGECONFIG_ledge-ti-am64xx = "optee"
 #EXTRA_OEMAKE_ADDONS_ledge-ti-am64xx = "TARGET_BOARD=\"${generic}\" "
 
-# Make ATF "aware" of OPTEE, no build dependency
-PACKAGECONFIG[optee] = " SPD=opteed "
+# Add TF-A options on aarch64 only for now. We might need it for armv7 in the
+# future
+EXTRA_OEMAKE_append_aarch64 = "${@bb.utils.contains('MACHINE_FEATURES', 'optee', ' SPD=opteed ', '', d)}"
 
 # Extra make settings
 EXTRA_OEMAKE = ' CROSS_COMPILE=${TARGET_PREFIX} '

--- a/meta-ledge-bsp/recipes-kernel/linux/linux-ledge/0004-op-tee-shm.patch
+++ b/meta-ledge-bsp/recipes-kernel/linux/linux-ledge/0004-op-tee-shm.patch
@@ -1,11 +1,20 @@
+---
+
+Changes in v2:
+Merge the dependency patch: https://lkml.org/lkml/2019/10/31/431
+
+ drivers/tee/optee/call.c     |  7 +++++++
+ drivers/tee/optee/shm_pool.c | 12 +++++++++++-
+ 2 files changed, 18 insertions(+), 1 deletion(-)
+
 diff --git a/drivers/tee/optee/call.c b/drivers/tee/optee/call.c
 index 13b0269..cf2367b 100644
 --- a/drivers/tee/optee/call.c
 +++ b/drivers/tee/optee/call.c
 @@ -554,6 +554,13 @@ static int check_mem_type(unsigned long start, size_t num_pages)
-	struct mm_struct *mm = current->mm;
-	int rc;
-
+ 	struct mm_struct *mm = current->mm;
+ 	int rc;
+ 
 +	/*
 +	 * Allow kernel address to register with OP-TEE as kernel
 +	 * pages are configured as normal memory only.
@@ -13,43 +22,43 @@ index 13b0269..cf2367b 100644
 +	if (virt_addr_valid(start))
 +		return 0;
 +
-	down_read(&mm->mmap_sem);
-	rc = __check_mem_type(find_vma(mm, start),
-				start + num_pages * PAGE_SIZE);
+ 	down_read(&mm->mmap_sem);
+ 	rc = __check_mem_type(find_vma(mm, start),
+ 			      start + num_pages * PAGE_SIZE);
 diff --git a/drivers/tee/optee/shm_pool.c b/drivers/tee/optee/shm_pool.c
 index de1d9b8..0332a53 100644
 --- a/drivers/tee/optee/shm_pool.c
 +++ b/drivers/tee/optee/shm_pool.c
 @@ -17,6 +17,7 @@ static int pool_op_alloc(struct tee_shm_pool_mgr *poolm,
  {
-	unsigned int order = get_order(size);
-	struct page *page;
+ 	unsigned int order = get_order(size);
+ 	struct page *page;
 +	int rc = 0;
-
-	page = alloc_pages(GFP_KERNEL | __GFP_ZERO, order);
-	if (!page)
+ 
+ 	page = alloc_pages(GFP_KERNEL | __GFP_ZERO, order);
+ 	if (!page)
 @@ -26,12 +27,21 @@ static int pool_op_alloc(struct tee_shm_pool_mgr *poolm,
-	shm->paddr = page_to_phys(page);
-	shm->size = PAGE_SIZE << order;
-
+ 	shm->paddr = page_to_phys(page);
+ 	shm->size = PAGE_SIZE << order;
+ 
 -	return 0;
 +	if (shm->flags & TEE_SHM_DMA_BUF) {
 +		shm->flags |= TEE_SHM_REGISTER;
 +		rc = optee_shm_register(shm->ctx, shm, &page, 1 << order,
-+								(unsigned long)shm->kaddr);
++					(unsigned long)shm->kaddr);
 +	}
 +
 +	return rc;
  }
-
+ 
  static void pool_op_free(struct tee_shm_pool_mgr *poolm,
-			 struct tee_shm *shm)
+ 			 struct tee_shm *shm)
  {
 +	if (shm->flags & TEE_SHM_DMA_BUF)
 +		optee_shm_unregister(shm->ctx, shm);
 +
-	free_pages((unsigned long)shm->kaddr, get_order(shm->size));
-	shm->kaddr = NULL;
+ 	free_pages((unsigned long)shm->kaddr, get_order(shm->size));
+ 	shm->kaddr = NULL;
  }
---
+-- 
 2.7.4

--- a/meta-ledge-bsp/recipes-kernel/linux/linux-ledge/0005-op-tee-multi-page-shm.patch
+++ b/meta-ledge-bsp/recipes-kernel/linux/linux-ledge/0005-op-tee-multi-page-shm.patch
@@ -1,11 +1,15 @@
+---
+ drivers/tee/optee/shm_pool.c | 14 +++++++++++++-
+ 1 file changed, 13 insertions(+), 1 deletion(-)
+
 diff --git a/drivers/tee/optee/shm_pool.c b/drivers/tee/optee/shm_pool.c
 index 0332a53..85aa5bb 100644
 --- a/drivers/tee/optee/shm_pool.c
 +++ b/drivers/tee/optee/shm_pool.c
 @@ -28,8 +28,20 @@ static int pool_op_alloc(struct tee_shm_pool_mgr *poolm,
-	shm->size = PAGE_SIZE << order;
-
-	if (shm->flags & TEE_SHM_DMA_BUF) {
+ 	shm->size = PAGE_SIZE << order;
+ 
+ 	if (shm->flags & TEE_SHM_DMA_BUF) {
 +		unsigned int nr_pages = 1 << order, i;
 +		struct page **pages;
 +
@@ -18,11 +22,11 @@ index 0332a53..85aa5bb 100644
 +			page++;
 +		}
 +
-		shm->flags |= TEE_SHM_REGISTER;
+ 		shm->flags |= TEE_SHM_REGISTER;
 -		rc = optee_shm_register(shm->ctx, shm, &page, 1 << order,
 +		rc = optee_shm_register(shm->ctx, shm, pages, nr_pages,
-								(unsigned long)shm->kaddr);
-	}
-
---
+ 					(unsigned long)shm->kaddr);
+ 	}
+ 
+-- 
 2.7.4


### PR DESCRIPTION
Corectly add SPD=opteed in build options for TF-A in aarch64

Signed-off-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>