### PR TITLE
ledge-armqemu64: add qemu dtb with ftpm

### DIFF
--- a/meta-ledge-bsp/conf/machine/ledge-qemuarm64.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-qemuarm64.conf
@@ -34,6 +34,7 @@ EXTRA_IMAGEDEPENDS_append = " virtual/bootloader"
 MACHINE_EXTRA_RRECOMMENDS += " \
     optee-os \
     arm-trusted-firmware-ledge \
+    qemudtb-ledge-qemu \
     "
 
 # WIC

--- a/meta-ledge-bsp/recipes-bsp/qemudtb/files/0001-qemuarm64.dts-add-ftpm-support.patch
+++ b/meta-ledge-bsp/recipes-bsp/qemudtb/files/0001-qemuarm64.dts-add-ftpm-support.patch
@@ -1,0 +1,30 @@
+From 54c361139abf3c4ef59673027c7c0f71e3bebe0d Mon Sep 17 00:00:00 2001
+From: Maxim Uvarov <maxim.uvarov@linaro.org>
+Date: Fri, 22 Nov 2019 14:16:44 +0000
+Subject: [PATCH] qemuarm64.dts: add ftpm support
+
+Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>
+---
+ virt.dts | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/virt.dts b/virt.dts
+index b9754fc..59d7801 100644
+--- a/virt.dts
++++ b/virt.dts
+@@ -6,6 +6,12 @@
+ 	#address-cells = <0x2>;
+ 	compatible = "linux,dummy-virt";
+ 
++	tpm@0 {
++		compatible = "microsoft,ftpm";
++		linux,sml-base = <0x0 0xC0000000>;
++		linux,sml-size = <0x10000>;
++	};
++
+ 	platform@c000000 {
+ 		interrupt-parent = <0x8001>;
+ 		ranges = <0x0 0x0 0xc000000 0x2000000>;
+-- 
+2.17.1
+

--- a/meta-ledge-bsp/recipes-bsp/qemudtb/qemudtb-ledge-qemu.bb
+++ b/meta-ledge-bsp/recipes-bsp/qemudtb/qemudtb-ledge-qemu.bb
@@ -1,0 +1,25 @@
+HOMEPAGE = "none"
+SECTION = "bootloaders"
+DEPENDS += "flex-native bison-native"
+PROVIDES += "qemudtb-ledge-qemu"
+
+LICENSE = "GPLv2+"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
+PE = "1"
+
+S = "${WORKDIR}/git"
+
+SRC_URI_append_ledge-qemuarm64 = " file://0001-qemuarm64.dts-add-ftpm-support.patch;apply=no"
+
+
+do_deploy_append_ledge-qemuarm64() {
+    qemu-system-aarch64 -nographic -machine virt,secure -cpu cortex-a57 -machine dumpdtb=virt.dtb
+    dtc -I dtb -O dts virt.dtb -o virt.dts
+    patch -p1 -r - < ${WORKDIR}/0001-qemuarm64.dts-add-ftpm-support.patch
+    dtc -I dts -O dtb virt.dts -o ${DEPLOYDIR}/ledge-qemuarm64.dtb
+    rm virt.dts virt.dts.orig virt.dtb
+}
+
+DEPENDS += "dtc-native qemu-helper-native"
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+COMPATIBLE_MACHINE = "(ledge-qemuarm|ledge-qemuarm64)"


### PR DESCRIPTION
qemu has dbt build in in qemu binary, which loads once qemu
boots. We need to add ftpm to that dtb.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>