### PR TITLE
qemu: do not install ext4 and tar rootfs

### DIFF
--- a/meta-ledge-bsp/conf/machine/ledge-qemuarm.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-qemuarm.conf
@@ -28,6 +28,7 @@ MACHINE_EXTRA_RRECOMMENDS += " \
     "
 
 # WIC
+IMAGE_FSTYPES_remove += "tar.bz2 tar.xz ext4"
 IMAGE_FSTYPES += "wic"
 WKS_FILE += "ledge-kernel-uefi.wks.in"
 

--- a/meta-ledge-bsp/conf/machine/ledge-qemuarm64.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-qemuarm64.conf
@@ -38,6 +38,7 @@ MACHINE_EXTRA_RRECOMMENDS += " \
     "
 
 # WIC
+IMAGE_FSTYPES_remove += "tar.bz2 tar.xz ext4"
 IMAGE_FSTYPES += "wic"
 WKS_FILE += "ledge-kernel-uefi.wks.in"
 


### PR DESCRIPTION
save disk space and deploy only wic image.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>