### PR TITLE
qemu: u-boot: disable u-boot and and set delay to 0

### DIFF
--- a/meta-ledge-bsp/recipes-bsp/u-boot/u-boot-ledge-qemu/ledge-qemuarm64_defconfig
+++ b/meta-ledge-bsp/recipes-bsp/u-boot/u-boot-ledge-qemu/ledge-qemuarm64_defconfig
@@ -238,7 +238,7 @@ CONFIG_BOOTSTAGE_STASH_SIZE=0x1000
 # CONFIG_SATA_BOOT is not set
 # CONFIG_SD_BOOT is not set
 # CONFIG_SPI_BOOT is not set
-CONFIG_BOOTDELAY=2
+CONFIG_BOOTDELAY=0
 # CONFIG_USE_BOOTARGS is not set
 CONFIG_USE_BOOTCOMMAND=y
 CONFIG_BOOTCOMMAND="setenv kernel_addr_r 0x60000000; setenv bootargs 'rootwait root=PARTLABEL=rootfs'; efidebug boot add 0000 'kernel' virtio 0:1 /efi/boot/bootaa64.efi; efidebug boot order 0000; bootefi bootmgr"
@@ -591,11 +591,11 @@ CONFIG_MKIMAGE_DTC_PATH="dtc"
 #
 # Environment
 #
-# CONFIG_ENV_IS_NOWHERE is not set
+CONFIG_ENV_IS_NOWHERE=y
 # CONFIG_ENV_IS_IN_EEPROM is not set
 # CONFIG_ENV_IS_IN_FAT is not set
 # CONFIG_ENV_IS_IN_EXT4 is not set
-CONFIG_ENV_IS_IN_FLASH=y
+# CONFIG_ENV_IS_IN_FLASH is not set
 # CONFIG_ENV_IS_IN_NAND is not set
 # CONFIG_ENV_IS_IN_NVRAM is not set
 # CONFIG_ENV_IS_IN_ONENAND is not set

--- a/meta-ledge-bsp/recipes-bsp/u-boot/u-boot-ledge-qemu/ledge-qemuarm_defconfig
+++ b/meta-ledge-bsp/recipes-bsp/u-boot/u-boot-ledge-qemu/ledge-qemuarm_defconfig
@@ -229,7 +229,7 @@ CONFIG_BOOTSTAGE_STASH_SIZE=0x1000
 # CONFIG_SATA_BOOT is not set
 # CONFIG_SD_BOOT is not set
 # CONFIG_SPI_BOOT is not set
-CONFIG_BOOTDELAY=2
+CONFIG_BOOTDELAY=0
 # CONFIG_USE_BOOTARGS is not set
 CONFIG_USE_BOOTCOMMAND=y
 CONFIG_BOOTCOMMAND="setenv kernel_addr_r 0x60000000; setenv bootargs 'rootwait root=PARTLABEL=rootfs'; efidebug boot add 0000 'kernel' virtio 0:1 /efi/boot/bootarm.efi; efidebug boot order 0000; bootefi bootmgr"
@@ -588,11 +588,11 @@ CONFIG_MKIMAGE_DTC_PATH="dtc"
 #
 # Environment
 #
-# CONFIG_ENV_IS_NOWHERE is not set
+CONFIG_ENV_IS_NOWHERE=y
 # CONFIG_ENV_IS_IN_EEPROM is not set
 # CONFIG_ENV_IS_IN_FAT is not set
 # CONFIG_ENV_IS_IN_EXT4 is not set
-CONFIG_ENV_IS_IN_FLASH=y
+# CONFIG_ENV_IS_IN_FLASH is not set
 # CONFIG_ENV_IS_IN_NAND is not set
 # CONFIG_ENV_IS_IN_NVRAM is not set
 # CONFIG_ENV_IS_IN_ONENAND is not set


### PR DESCRIPTION
Since the QEMU platforms will load PE/KEK/db/dbx from a virtio device,
until we implement secure storage in QEMU wee need a way of protecting
the UEFI variables.

Let's disable the u-boot env and set the bootdelay to 0
so the user can't change those for U-Boot's command line

Signed-off-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>