### PR TITLE
ledge-qemuarm64: run kernel with signed certificates

### DIFF
--- a/meta-ledge-bsp/conf/machine/ledge-qemuarm64.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-qemuarm64.conf
@@ -48,7 +48,7 @@ QB_MACHINE = "-machine virt,secure=on"
 QB_CPU = "-cpu cortex-a57"
 QB_KERNEL_CMDLINE_APPEND = "console=ttyAMA0,38400"
 # Add the 'virtio-rng-pci' device otherwise the guest may run out of entropy
-QB_OPT_APPEND = "-show-cursor -device virtio-rng-pci -monitor null -nographic -d unimp -semihosting-config enable,target=native -bios bl1.bin -dtb ledge-qemuarm64.dtb"
+QB_OPT_APPEND = "-show-cursor -device virtio-rng-pci -monitor null -nographic -d unimp -semihosting-config enable,target=native -bios bl1.bin -dtb ledge-qemuarm64.dtb -drive id=disk1,file=ledge-kernel-uefi-certs.ext4,if=none,format=raw -device virtio-blk-device,drive=disk1"
 QB_SERIAL_OPT = "-device virtio-serial-device -chardev null,id=virtcon -device virtconsole,chardev=virtcon"
 QB_DRIVE_TYPE = "/dev/vdb"
 QB_ROOTFS_OPT = "-drive id=disk0,file=@ROOTFS@,if=none,format=raw -device virtio-blk-device,drive=disk0"

--- a/meta-ledge-bsp/recipes-bsp/u-boot/u-boot-ledge-qemu/ledge-qemuarm64_defconfig
+++ b/meta-ledge-bsp/recipes-bsp/u-boot/u-boot-ledge-qemu/ledge-qemuarm64_defconfig
@@ -241,7 +241,7 @@ CONFIG_BOOTSTAGE_STASH_SIZE=0x1000
 CONFIG_BOOTDELAY=0
 # CONFIG_USE_BOOTARGS is not set
 CONFIG_USE_BOOTCOMMAND=y
-CONFIG_BOOTCOMMAND="setenv kernel_addr_r 0x60000000; setenv bootargs 'rootwait root=PARTLABEL=rootfs'; efidebug boot add 0000 'kernel' virtio 0:1 /efi/boot/bootaa64.efi; efidebug boot order 0000; bootefi bootmgr"
+CONFIG_BOOTCOMMAND="load virtio 0 0x70000000 kernel.auth;setenv -e -nv -bs -rt -at -i 0x70000000,$filesize db; load virtio 0 0x70000000 KEK.auth; setenv -e -nv -bs -rt -at -i 0x70000000,$filesize KEK; load virtio 0 0x70000000 PK.auth;setenv -e -nv -bs -rt -at -i 0x70000000,$filesize PK; setenv kernel_addr_r 0x60000000; setenv bootargs 'rootwait root=PARTLABEL=rootfs'; efidebug boot add 0000 'kernel' virtio 1:1 /efi/boot/bootaa64.efi; efidebug boot order 0000; bootefi bootmgr"
 CONFIG_USE_PREBOOT=y
 CONFIG_PREBOOT="pci enum"
 


### PR DESCRIPTION
qemuparams="..." or QB_OPT_APPEND append option after first
rootfs.  So that virtio-0 is certs image and virtio-1 is
kernel and rootfs.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>