### PR TITLE
finally fix qemuarmv7 part 2

### DIFF
--- a/meta-ledge-bsp/conf/machine/ledge-qemuarm.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-qemuarm.conf
@@ -30,7 +30,7 @@ UBOOT_DEVICETREE = "qemu_arm.dtb"
 UBOOT_CONFIG[basic]   = "ledge-qemuarm_defconfig,,u-boot.bin"
 EXTRA_IMAGEDEPENDS_append = " virtual/bootloader"
 
-MACHINE_EXTRA_RRECOMMENDS += " \
+MACHINE_EXTRA_RDEPENDS += " \
     optee-os \
     arm-trusted-firmware-ledge \
     qemudtb-ledge-qemu \

--- a/meta-ledge-bsp/conf/machine/ledge-qemuarm64.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-qemuarm64.conf
@@ -31,7 +31,7 @@ UBOOT_DEVICETREE = "qemu_arm64.dtb"
 UBOOT_CONFIG[basic]   = "ledge-qemuarm64_defconfig,,u-boot.bin"
 EXTRA_IMAGEDEPENDS_append = " virtual/bootloader"
 
-MACHINE_EXTRA_RRECOMMENDS += " \
+MACHINE_EXTRA_RDEPENDS += " \
     optee-os \
     arm-trusted-firmware-ledge \
     qemudtb-ledge-qemu \

--- a/meta-ledge-bsp/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware-ledge_git.bb
+++ b/meta-ledge-bsp/recipes-bsp/arm-trusted-firmware/arm-trusted-firmware-ledge_git.bb
@@ -7,14 +7,16 @@ Power State Coordination Interface (PSCI), Trusted Board Boot Requirements \
 HOMEPAGE = "http://infocenter.arm.com/help/topic/com.arm.doc.dui0928e/CJHIDGJF.html"
 
 LICENSE = "BSD-3-Clause"
-LIC_FILES_CHKSUM = "file://license.rst;md5=90153916317c204fade8b8df15739cde"
+LIC_FILES_CHKSUM = "file://license.rst;md5=1dd070c98a281d18d9eefd938729b031"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 PV = "2.1"
 
 SRC_URI = "git://github.com/ARM-software/arm-trusted-firmware.git;protocol=https;nobranch=1"
-SRCREV = "bb2d778c749ed772be8a2eb6f08356d2d03d9b1a"
+SRCREV = "76f25eb52b10d56b8b54fc63d748c15e428e409a"
+
+ALLOW_EMPTY_${PN} = "1"
 
 S = "${WORKDIR}/git"
 B = "${WORKDIR}/build"
@@ -25,38 +27,22 @@ DEPENDS += "dtc-native"
 
 # ledge-stm32mp157c-dk2 specific
 TF_A_PLATFORM_ledge-stm32mp157c-dk2 = "stm32mp1"
-EXTRA_OEMAKE_ADDONS_ledge-stm32mp157c-dk2 = "AARCH32_SP=optee"
 TF_A_DEVICETREE_ledge-stm32mp157c-dk2 = "stm32mp157c-dk2"
 
 # ledge-qemuarm specific
 TF_A_PLATFORM_ledge-qemuarm = "qemu"
-EXTRA_OEMAKE_ADDONS_ledge-qemuarm = ""
-TF_A_DEVICETREE_ledge-qemuarm = ""
-TF_A_CONFIG_ledge-qemuarm = "qemu_arm_defconfig"
 
 # ledge-qemuarm64 specific
 TF_A_PLATFORM_ledge-qemuarm64 = "qemu"
-EXTRA_OEMAKE_ADDONS_ledge-qemuarm64 = ""
-TF_A_DEVICETREE_ledge-qemuarm64 = ""
-TF_A_CONFIG_ledge-qemuarm64 = "qemu_arm64_defconfig"
-
-# ledge-ti-am64xx specific
-#TF_A_SUFFIX_ledge-ti-am64xx = "stm32"
-#TF_A_PLATFORM_ledge-ti-am64xx = "stm32mp1"
-#TF_A_CONFIG_ledge-ti-am64xx = "optee"
-#TF_A_TARGET_BOARD_ledge-ti-am64xx = "generic"
-#PACKAGECONFIG_ledge-ti-am64xx = "optee"
-#EXTRA_OEMAKE_ADDONS_ledge-ti-am64xx = "TARGET_BOARD=\"${generic}\" "
-
-# Add TF-A options on aarch64 only for now. We might need it for armv7 in the
-# future
-EXTRA_OEMAKE_append_aarch64 = "${@bb.utils.contains('MACHINE_FEATURES', 'optee', ' SPD=opteed ', '', d)}"
 
 # Extra make settings
 EXTRA_OEMAKE = ' CROSS_COMPILE=${TARGET_PREFIX} '
 EXTRA_OEMAKE += ' PLAT=${TF_A_PLATFORM} '
 EXTRA_OEMAKE_append_armv7a = ' ARCH=aarch32 ARM_ARCH_MAJOR=7 '
 EXTRA_OEMAKE_append_armv7ve = ' ARCH=aarch32 ARM_ARCH_MAJOR=7 '
+EXTRA_OEMAKE_append_ledge-stm32mp157c-dk2 = "AARCH32_SP=optee"
+EXTRA_OEMAKE_append_ledge-qemuarm = ' AARCH32_SP=optee ARM_TSP_RAM_LOCATION=tdram BL32_RAM_LOCATION=tdram '
+EXTRA_OEMAKE_append_aarch64 = "${@bb.utils.contains('MACHINE_FEATURES', 'optee', ' SPD=opteed ', '', d)}"
 
 # Debug support
 EXTRA_OEMAKE += 'DEBUG=1'
@@ -75,10 +61,10 @@ do_compile() {
 do_compile_ledge-stm32mp157c-dk2() {
     if [ -n "${TF_A_DEVICETREE}" ]; then
         for dt in ${TF_A_DEVICETREE}; do
-            oe_runmake -C ${S} DTB_FILE_NAME=${dt}.dtb BUILD_PLAT=${B} ${EXTRA_OEMAKE_ADDONS} all
+            oe_runmake -C ${S} DTB_FILE_NAME=${dt}.dtb BUILD_PLAT=${B} all
         done
     else
-            oe_runmake -C ${S} BUILD_PLAT=${B} ${EXTRA_OEMAKE_ADDONS} all
+            oe_runmake -C ${S} BUILD_PLAT=${B} all
     fi
 }
 
@@ -104,6 +90,14 @@ do_install() {
         install -m 0644 ${B}/bl32.bin ${D}/boot/
         install -m 0644 ${B}/bl32/bl32.elf ${D}/boot/
     fi
+}
+
+do_install_ledge-qemuarm() {
+	echo "nothing"
+}
+
+do_install_ledge-qemuarm64() {
+	echo "nothing"
 }
 
 do_deploy() {

--- a/meta-ledge-bsp/recipes-bsp/qemudtb/qemudtb-ledge-qemu.bb
+++ b/meta-ledge-bsp/recipes-bsp/qemudtb/qemudtb-ledge-qemu.bb
@@ -8,6 +8,8 @@ PR = "r1"
 
 inherit deploy
 
+ALLOW_EMPTY_${PN} = "1"
+
 SRC_URI_append = " file://0001-qemuarm64.dts-add-ftpm-support.patch;apply=no"
 
 do_deploy () {
@@ -20,7 +22,7 @@ do_deploy_append_ledge-qemuarm() {
     -device virtio-net-pci,netdev=net0,mac=52:54:00:12:34:02 -netdev user,id=net0 \
     -drive id=disk0,file=dummy.wic,if=none,format=raw -device virtio-blk-device,drive=disk0 -show-cursor -device virtio-rng-pci \
     -monitor null -nographic -d unimp -semihosting-config enable,target=native -bios bl1.bin \
-    -machine virt,secure=on -m 4096 -serial mon:stdio -serial null \
+    -machine virt,secure=on -cpu cortex-a15 -m 1024 -serial mon:stdio -serial null \
     -machine dumpdtb=virt.dtb
 
     dtc -I dtb -O dts virt.dtb -o virt.dts

--- a/meta-ledge-bsp/recipes-bsp/u-boot/u-boot-ledge-qemu.bb
+++ b/meta-ledge-bsp/recipes-bsp/u-boot/u-boot-ledge-qemu.bb
@@ -7,9 +7,10 @@ LICENSE = "GPLv2+"
 LIC_FILES_CHKSUM = "file://Licenses/README;md5=30503fd321432fc713238f582193b78e"
 PE = "1"
 
-# We use the revision in order to avoid having to fetch it from the
-# repo during parse
-SRCREV = "49c18f12f6377afde18dd7b38ad3bae1db31cec3"
+# This autentification uboot patches are not yet upstream. Using branch without
+# SRCREV untill upstream happens.
+# SRCREV = "49c18f12f6377afde18dd7b38ad3bae1db31cec3"
+SRCREV = "${AUTOREV}"
 
 SRC_URI = "git://git.linaro.org/people/takahiro.akashi/u-boot.git;branch=efi/secboot"
 

--- a/meta-ledge-bsp/recipes-bsp/u-boot/u-boot-ledge-qemu/ledge-qemuarm_defconfig
+++ b/meta-ledge-bsp/recipes-bsp/u-boot/u-boot-ledge-qemu/ledge-qemuarm_defconfig
@@ -152,7 +152,7 @@ CONFIG_ARCH_QEMU=y
 # CONFIG_ARCH_ASPEED is not set
 CONFIG_ARCH_SUPPORT_TFABOOT=y
 CONFIG_TFABOOT=y
-CONFIG_SYS_TEXT_BASE=0x00000000
+CONFIG_SYS_TEXT_BASE=0x60000000
 CONFIG_SYS_MALLOC_F_LEN=0x400
 CONFIG_BOARD_SPECIFIC_OPTIONS=y
 CONFIG_TARGET_QEMU_ARM_32BIT=y
@@ -232,7 +232,7 @@ CONFIG_BOOTSTAGE_STASH_SIZE=0x1000
 CONFIG_BOOTDELAY=0
 # CONFIG_USE_BOOTARGS is not set
 CONFIG_USE_BOOTCOMMAND=y
-CONFIG_BOOTCOMMAND="load virtio 0 0x70000000 kernel.auth; setenv -e -nv -bs -rt -at -i 0x70000000,$filesize db; load virtio 0 0x70000000 KEK.auth; setenv -e -nv -bs -rt -at -i 0x70000000,$filesize KEK; load virtio 0 0x70000000 PK.auth; setenv -e -nv -bs -rt -at -i 0x70000000,$filesize PK; setenv kernel_addr_r 0x60000000; setenv bootargs 'rootwait root=PARTLABEL=rootfs'; efidebug boot add 0000 'kernel' virtio 1:1 /efi/boot/bootarm.efi; efidebug boot order 0000; bootefi bootmgr"
+CONFIG_BOOTCOMMAND="load virtio 0 0x70000000 kernel.auth; setenv -e -nv -bs -rt -at -i 0x70000000,$filesize db; load virtio 0 0x70000000 KEK.auth; setenv -e -nv -bs -rt -at -i 0x70000000,$filesize KEK; load virtio 0 0x70000000 PK.auth; setenv -e -nv -bs -rt -at -i 0x70000000,$filesize PK; setenv kernel_addr_r 0x60000000; setenv bootargs 'rootwait root=PARTLABEL=rootfs console=ttyAMA0,115200 earlyprintk=serial,ttyAMA0,115200'; efidebug boot add 0000 'kernel' virtio 1:1 /efi/boot/bootarm.efi; efidebug boot order 0000; bootefi bootmgr"
 CONFIG_USE_PREBOOT=y
 CONFIG_PREBOOT="pci enum"
 

--- a/meta-ledge-bsp/recipes-security/optee/optee-os_git.bbappend
+++ b/meta-ledge-bsp/recipes-security/optee/optee-os_git.bbappend
@@ -19,7 +19,6 @@ EXTRA_OEMAKE_remove_ledge-ti-am572x = "ta-targets=ta_arm64"
 EXTRA_OEMAKE_append_ledge-ti-am572x = "CFG_ARM32_core=y ta-targets=ta_arm32 "
 EXTRA_OEMAKE_append_ledge-ti-am572x = " CROSS_COMPILE_ta_arm32=${HOST_PREFIX} CROSS_COMPILE=${CROSS_COMPILE} "
 
-# armv7
 EXTRA_OEMAKE_remove_armv7a = "CFG_ARM64_core=y"
 EXTRA_OEMAKE_remove_armv7a = "ta-targets=ta_arm64"
 EXTRA_OEMAKE_append_armv7a = " CFG_ARM32_core=y ta-targets=ta_arm32"
@@ -33,6 +32,7 @@ EXTRA_OEMAKE_append_ledge-stm32mp157c-dk2 = " CFG_EMBED_DTB_SOURCE_FILE=stm32mp1
 # add traces at startup
 EXTRA_OEMAKE_append = "CFG_TEE_CORE_DEBUG=n CFG_TEE_CORE_LOG_LEVEL=2"
 
+OPTEE_ARCH_armv7a = "arm32"
 OPTEE_ARCH_armv7ve = "arm32"
 
 do_install_append_ledge-stm32mp157c-dk2() {


### PR DESCRIPTION
This patch make runqemu command run for ledge-qemuarm. Changes
touch cleanups in atf, uboot, optee and machine config files.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>