### PR TITLE
FLASHLAYOUT: correct wrong extension of kernel module

### DIFF
--- a/meta-ledge-bsp/recipes-devtools/generate-raw-image/files/aarch64/FlashLayout_sdcard_arm64_without_boot_firmware.fld
+++ b/meta-ledge-bsp/recipes-devtools/generate-raw-image/files/aarch64/FlashLayout_sdcard_arm64_without_boot_firmware.fld
@@ -12,7 +12,7 @@
 #Ofsset on hexa
 #Opt	Name	Type	Offset	Binary
 URI		https://snapshots.linaro.org/components/ledge/oe/ledge-qemuarm64/latest/rpb/
-MODULE	modules-stripped-ledge-qemuarm64-for-debian.tar.gz
+MODULE	modules-stripped-ledge-qemuarm64-for-debian.tgz
 KERNEL	Image-for-debian
 DTB		none
 ARCH	arm64

--- a/meta-ledge-bsp/recipes-devtools/generate-raw-image/files/armv7a/FlashLayout_sdcard_armhf_without_boot_firmware.fld
+++ b/meta-ledge-bsp/recipes-devtools/generate-raw-image/files/armv7a/FlashLayout_sdcard_armhf_without_boot_firmware.fld
@@ -12,7 +12,7 @@
 #Ofsset on hexa
 #Opt	Name	Type	Offset	Binary
 URI		https://snapshots.linaro.org/components/ledge/oe/ledge-quemuarm/latest/rpb/
-MODULE	modules-stripped-ledge-quemuarm-for-debian.tar.gz
+MODULE	modules-stripped-ledge-quemuarm-for-debian.tgz
 KERNEL	zImage-for-debian
 DTB		none
 ARCH	armhf

--- a/meta-ledge-bsp/recipes-devtools/generate-raw-image/files/ledge-stm32mp157c-dk2/FlashLayout_sdcard_ledge-stm32mp157c-dk2-debian.fld
+++ b/meta-ledge-bsp/recipes-devtools/generate-raw-image/files/ledge-stm32mp157c-dk2/FlashLayout_sdcard_ledge-stm32mp157c-dk2-debian.fld
@@ -12,7 +12,7 @@
 #Ofsset on hexa
 #Opt	Name	Type	Offset	Binary
 URI		https://snapshots.linaro.org/components/ledge/oe/ledge-stm32mp157c-dk2/latest/rpb/
-MODULE	modules-stripped-ledge-stm32mp157c-dk2-for-debian.tar.gz
+MODULE	modules-stripped-ledge-stm32mp157c-dk2-for-debian.tgz
 KERNEL	zImage-for-debian
 DTB		stm32mp157c-dk2.dtb-for-debian
 ARCH	armhf


### PR DESCRIPTION
Due to upload script, the extension must be tgz instead of tar.gz

Signed-off-by: Christophe Priouzeau <christophe.priouzeau@st.com>