### PR TITLE
bsp: ti: Boot am572x with UEFI

### DIFF
--- a/meta-ledge-bsp/conf/machine/ledge-ti-am572x.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-ti-am572x.conf
@@ -29,8 +29,15 @@ MACHINE_EXTRA_RRECOMMENDS = "prueth-fw optee-os"
 MACHINE_FEATURES += "optee"
 MACHINE_FEATURES += "tsn"
 
-KERNEL_EXTRA_ARGS_append_ledge-ti-am572x += "LOADADDR=${UBOOT_ENTRYPOINT}"
 RDEPENDS_${KERNEL_PACKAGE_NAME}-base_append_ledge-ti-am572x = " prueth-fw"
 FILES_${KERNEL_PACKAGE_NAME}-devicetree_append_ledge-ti-am572x += "/${KERNEL_IMAGEDEST}/*.itb"
 
-IMAGE_FSTYPES_append = " ext4 "
+KERNEL_IMAGETYPES = "zImage"
+
+# WIC
+# U-Boot provided DTB does not work, use an external on for now, 
+# until we manage to embed the proper DTB 
+IMAGE_BOOT_FILES ?= "u-boot.img MLO am572x-idk.dtb"
+IMAGE_FSTYPES_remove += "tar.bz2 tar.xz ext4"
+IMAGE_FSTYPES += "wic"
+WKS_FILE += "ledge-ti-am572x.wks.in"

--- a/meta-ledge-bsp/wic/ledge-ti-am572x.wks.in
+++ b/meta-ledge-bsp/wic/ledge-ti-am572x.wks.in
@@ -1,0 +1,6 @@
+# short-description: Create SD card image with a boot partition
+# long-description: Creates a partitioned SD card image
+#
+part firmware --source bootimg-partition --fstype=vfat --label firmware --active --align 4 --size 16
+part /boot --source rootfs --rootfs-dir=${IMAGE_ROOTFS}/boot --fstype=vfat --label boot --align 4 --fixed-size 64M --use-uuid
+part / --source rootfs --fstype=ext4 --label rootfs --align 4 --exclude-path boot/


### PR DESCRIPTION
Create a WIC image that contains three partitions.
First one is firmware + dtb. Use an external dtb for now since the
U-Boot embedded one is not up to date. Second partition has the kernel
only and the third one rootfs.

In order to boot the board with UEFI use:
setenv bootargs 'efi=novamap,noruntime console=ttyS2,115200 rootwait root=/dev/mmcblk0p3 selinux=0'
load mmc 0:1 $fdt_addr_r am572x-idk.dtb; load mmc 0:2 $kernel_addr_r efi/boot/bootarm.efi; bootefi $kernel_addr_r $fdt_addr_r

This will eventually be applied to TI u-boot config in a following patch

Signed-off-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>