### PR TITLE
enable wic image for qemu x86

### DIFF
--- a/meta-ledge-bsp/conf/machine/ledge-qemuarm.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-qemuarm.conf
@@ -34,6 +34,7 @@ MACHINE_EXTRA_RDEPENDS += " \
     optee-os \
     arm-trusted-firmware-ledge \
     qemudtb-ledge-qemu \
+    linux-ledge-uefi-keys \
     "
 
 # WIC

--- a/meta-ledge-bsp/conf/machine/ledge-qemuarm64.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-qemuarm64.conf
@@ -35,6 +35,7 @@ MACHINE_EXTRA_RDEPENDS += " \
     optee-os \
     arm-trusted-firmware-ledge \
     qemudtb-ledge-qemu \
+    linux-ledge-uefi-keys \
     "
 
 # WIC

--- a/meta-ledge-bsp/conf/machine/ledge-qemux86-64.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-qemux86-64.conf
@@ -32,9 +32,12 @@ XSERVER = "xserver-xorg \
            "
 
 MACHINE_FEATURES += "x86 pci"
+MACHINE_FEATURES += "pcbios efi"
 
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS += "v86d"
-EXTRA_IMAGEDEPENDS += "ovmf"
+EXTRA_IMAGEDEPENDS += " ovmf "
+EXTRA_IMAGEDEPENDS += " linux-ledge-uefi-keys "
+
 
 MACHINE_EXTRA_RRECOMMENDS = "kernel-module-snd-ens1370 kernel-module-snd-rawmidi"
 
@@ -42,12 +45,16 @@ KERNEL_MODULE_AUTOLOAD += "uvesafb"
 KERNEL_MODULE_PROBECONF += "uvesafb"
 module_conf_uvesafb = "options uvesafb mode_option=${UVESA_MODE}"
 
-WKS_FILE ?= "qemux86-directdisk.wks"
+# WIC
 do_image_wic[depends] += "syslinux:do_populate_sysroot syslinux-native:do_populate_sysroot mtools-native:do_populate_sysroot dosfstools-native:do_populate_sysroot"
+IMAGE_FSTYPES_remove += "tar.bz2 tar.xz ext4"
+IMAGE_FSTYPES += "wic"
+WKS_FILE += "ledge-kernel-uefi.wks.in"
 
 # For runqemu
+QB_SYSTEM_NAME = "qemu-system-x86_64"
 QB_MACHINE = ""
-QB_ROOTFS_OPT = "-drive if=virtio,file=@ROOTFS@ "
-QB_OPT_APPEND = "-nographic"
-QB_KERNEL_CMDLINE_APPEND = "console=ttyS0 console=tty"
-
+QB_CPU = ""
+QB_APPEND =  "-device virtio-rng-pci"
+QB_ROOTFS_OPT = "-drive id=disk0,file=@ROOTFS@,if=none,format=raw -device virtio-blk-pci,drive=disk0,bootindex=0"
+QB_SERIAL_OPT = "-serial mon:stdio"

--- a/meta-ledge-bsp/recipes-kernel/linux/linux-ledge-common.inc
+++ b/meta-ledge-bsp/recipes-kernel/linux/linux-ledge-common.inc
@@ -71,56 +71,6 @@ do_configure() {
     cp -a ${B}/defconfig ${DEPLOYDIR}
 }
 
-# -----------------------------------------------------
-#             EFI
-# Determine the target arch for kernel as EFI firmware
-python __anonymous () {
-    import re
-    target = d.getVar('TARGET_ARCH')
-    if target == "x86_64":
-        kernel_efi_image = "bootx64.efi"
-    elif re.match('i.86', target):
-        kernel_efi_image = "bootia32.efi"
-    elif re.match('aarch64', target):
-        kernel_efi_image = "bootaa64.efi"
-    elif re.match('arm', target):
-        kernel_efi_image = "bootarm.efi"
-    else:
-        raise bb.parse.SkipRecipe("kernel efi is incompatible with target %s" % target)
-    d.setVar("KERNEL_EFI_IMAGE", kernel_efi_image)
-}
-
-do_install_append() {
-    if [ "${@bb.utils.contains('DISTRO_FEATURES', 'efi', '1', '0', d)}" = "1" ]; then
-	   for img in bzImage zImage Image; do
-		if [ "x$img" = "x${KERNEL_IMAGETYPE}" ]; then
-			break;
-		fi
-		if [ "x$img" = "x${KERNEL_ALT_IMAGETYPE}" ]; then
-			break;
-		fi
-	   done
-
-	install -d ${D}/boot/efi/boot
-	cat ${D}/boot/${img} > ${D}/boot/efi/boot/${KERNEL_EFI_IMAGE}
-
-	for t in ${KERNEL_IMAGETYPE} ${KERNEL_ALT_IMAGETYPE}; do
-	    rm -rf ${D}/boot/$t*
-	done
-    fi
-}
-FILES_${KERNEL_PACKAGE_NAME}-image += "/boot/efi"
-
-python __anonymous () {
-    types = d.getVar('KERNEL_IMAGETYPES') or ""
-    kname = d.getVar('KERNEL_PACKAGE_NAME') or "kernel"
-    for type in types.split():
-        typelower = type.lower()
-        if typelower == 'zimage':
-            d.appendVar('FILES_' + kname + '-image-' + typelower, ' /boot/efi/boot ')
-        if typelower == 'image':
-            d.appendVar('FILES_' + kname + '-image-' + typelower, ' /boot/efi/boot ')
-}
 FILES_${KERNEL_PACKAGE_NAME}-base += "${nonarch_base_libdir}/modules/${KERNEL_VERSION}/modules.builtin.modinfo "
 
 # for debian purpose
@@ -139,14 +89,5 @@ do_deploy_append() {
     for d in  ${KERNEL_DEVICETREE}; do
         cp -f $deployDir/$d $deployDir/$d-for-debian
     done
-
-    hash-to-efi-sig-list ${D}/boot/efi/boot/${KERNEL_EFI_IMAGE} kernel.hash
-    sign-efi-sig-list -c ${WORKDIR}/uefi-certificates/KEK.crt -k ${WORKDIR}/uefi-certificates/KEK.key db kernel.hash kernel.auth
-    mkdir -p certimage
-    cp ${WORKDIR}/uefi-certificates/PK.auth ${WORKDIR}/uefi-certificates/KEK.auth kernel.auth ./certimage
-    truncate -s 4M certimage.ext4
-    ${STAGING_DIR_NATIVE}${base_sbindir}/mkfs.ext4 certimage.ext4 -d ./certimage
-    rm -rf ./certimage kernel.hash
-    mv certimage.ext4 ${DEPLOYDIR}/ledge-kernel-uefi-certs.ext4
 }
 do_deploy[depends] += " virtual/kernel:do_package "

--- a/meta-ledge-bsp/recipes-kernel/linux/linux-ledge-uefi-keys.bb
+++ b/meta-ledge-bsp/recipes-kernel/linux/linux-ledge-uefi-keys.bb
@@ -1,0 +1,32 @@
+DESCRIPTION = "Linux Kernel uefi keys"
+LICENSE = "GPLv2"
+SECTION = "kernel"
+DEPENDS = ""
+DEPENDS += "virtual/kernel"
+
+python __anonymous () {
+    import re
+    target = d.getVar('TARGET_ARCH')
+    if target == "x86_64":
+        kernel_efi_image = "bootx64.efi"
+    elif re.match('i.86', target):
+        kernel_efi_image = "bootia32.efi"
+    elif re.match('aarch64', target):
+        kernel_efi_image = "bootaa64.efi"
+    elif re.match('arm', target):
+        kernel_efi_image = "bootarm.efi"
+    else:
+        raise bb.parse.SkipRecipe("kernel efi is incompatible with target %s" % target)
+    d.setVar("KERNEL_EFI_IMAGE", kernel_efi_image)
+}
+
+do_deploy() {
+	hash-to-efi-sig-list ${D}/boot/efi/boot/${KERNEL_EFI_IMAGE} kernel.hash
+	sign-efi-sig-list -c ${WORKDIR}/uefi-certificates/KEK.crt -k ${WORKDIR}/uefi-certificates/KEK.key db kernel.hash kernel.auth
+	mkdir -p certimage
+	cp ${WORKDIR}/uefi-certificates/PK.auth ${WORKDIR}/uefi-certificates/KEK.auth kernel.auth ./certimage
+	truncate -s 4M certimage.ext4
+	mkfs.ext4 certimage.ext4 -d ./certimage
+	rm -rf ./certimage kernel.hash
+	mv certimage.ext4 ${DEPLOYDIR}/ledge-kernel-uefi-certs.ext4
+}

--- a/meta-ledge-bsp/wic/ledge-kernel-uefi.wks.in
+++ b/meta-ledge-bsp/wic/ledge-kernel-uefi.wks.in
@@ -1,3 +1,3 @@
 bootloader  --ptable gpt --timeout=0  --append="rootwait"
-part /boot --source rootfs --rootfs-dir=${IMAGE_ROOTFS}/boot --fstype=vfat --label bootfs --active --align 1024 --fixed-size 128M --use-uuid
+part /boot --source bootimg-efi --sourceparams="loader=kernel" --ondisk sda  --fstype=vfat --label bootfs --active --align 1024 --use-uuid
 part / --source rootfs --fstype=ext4 --label rootfs --align 1024 --exclude-path boot/ --use-label


### PR DESCRIPTION
This patch enables wic image for ledge-qemux86_64 and also makes
  'runqemu ledge-qemux86-64 ovmf wic nographic' command works.
OVMF can be used upstream or from current build. Patch also depends
on upstream fix to OE.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>