### PR TITLE
linux-ledge-uefi-keys-native: fix defining depends

### DIFF
--- a/meta-ledge-bsp/recipes-kernel/linux/linux-ledge-uefi-keys-native.bb
+++ b/meta-ledge-bsp/recipes-kernel/linux/linux-ledge-uefi-keys-native.bb
@@ -3,9 +3,9 @@ LICENSE = "GPLv2"
 SECTION = "kernel"
 
 # for mkfs.ext4
-DEPENDS += "e2fsprogs-native"
-DEPENDS += "efitools-native"
-DEPENDS += "coreutils-native"
+DEPENDS += " e2fsprogs-native "
+DEPENDS += " efitools-native "
+DEPENDS += " coreutils-native "
 
 DEPENDS += "linux-ledge"
 DEPENDS += "virtual/kernel"


### PR DESCRIPTION
+= appends string without whitespace. That leads to
wrong dependancies matches. For some reason bitbake
does not warn on this but fails to build because of
sysroot is not populated with dependancies.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>