### PR TITLE
kernel config: enable serial console

### DIFF
--- a/meta-ledge-bsp/recipes-kernel/linux/linux-ledge/fragment-13-cmdline.config
+++ b/meta-ledge-bsp/recipes-kernel/linux/linux-ledge/fragment-13-cmdline.config
@@ -1,2 +1,3 @@
 # cmdline
-CONFIG_CMDLINE="root=PARTLABEL=rootfs"
+CONFIG_CMDLINE_BOOL=y
+CONFIG_CMDLINE="root=PARTLABEL=rootfs console=ttyS0,115200"


### PR DESCRIPTION
by defaut serial conole is enabled for arm, arm64 but not
for x86. If we run qemu virtual machine we want to see
the same console.
Also turn on kernel built in command line.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>