### PR TITLE
images: Change efi partition generation for ti am572x

### DIFF
--- a/meta-ledge-bsp/wic/ledge-ti-am572x.wks.in
+++ b/meta-ledge-bsp/wic/ledge-ti-am572x.wks.in
@@ -2,5 +2,5 @@
 # long-description: Creates a partitioned SD card image
 #
 part firmware --source bootimg-partition --fstype=vfat --label firmware --active --align 4 --size 16
-part /boot --source rootfs --rootfs-dir=${IMAGE_ROOTFS}/boot --fstype=vfat --label boot --align 4 --fixed-size 64M --use-uuid
+part /boot --source bootimg-efi --sourceparams="loader=kernel" --fstype=vfat --label bootfs --align 4 --use-uuid
 part / --source rootfs --fstype=ext4 --label rootfs --align 4 --exclude-path boot/


### PR DESCRIPTION
Since we upstreamed our changes on WIC and bootefi module, use that while
generating the TI board ESP partition

Signed-off-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>