### PR TITLE
CONF: force generation of devicetree during for qemu machine

### DIFF
--- a/meta-ledge-bsp/recipes-kernel/linux/linux-ledge-common.inc
+++ b/meta-ledge-bsp/recipes-kernel/linux/linux-ledge-common.inc
@@ -10,6 +10,7 @@ KERNEL_CONFIG_FRAGMENTS_append = " ${WORKDIR}/fragment-11-virtio.config "
 KERNEL_CONFIG_FRAGMENTS_append = " ${WORKDIR}/fragment-12-security.config "
 KERNEL_CONFIG_FRAGMENTS_append = " ${WORKDIR}/fragment-13-cmdline.config "
 KERNEL_CONFIG_FRAGMENTS_append = " ${@oe.utils.ifelse(d.getVar('KERNEL_SIGN_ENABLE') == '1', '${WORKDIR}/fragment-14-module-signature.config','')} "
+KERNEL_CONFIG_FRAGMENTS_append = " ${WORKDIR}/fragment-15-cleanup.config "
 
 KERNEL_CONFIG_COMMAND = "oe_runmake -C ${S} O=${B} ${KERNEL_DEFCONFIG}"
 
@@ -20,6 +21,7 @@ SRC_URI_append = " file://fragment-11-virtio.config "
 SRC_URI_append = " file://fragment-12-security.config "
 SRC_URI_append = " file://fragment-13-cmdline.config "
 SRC_URI_append = " file://fragment-14-module-signature.config "
+SRC_URI_append = " file://fragment-15-cleanup.config "
 
 EXTRA_OEMAKE += "${@oe.utils.ifelse(d.getVar('KERNEL_SIGN_ENABLE') == '1', 'INSTALL_MOD_STRIP=1','')}"
 
@@ -61,6 +63,20 @@ do_configure() {
     bbplain "Saving defconfig to:\n${B}/defconfig"
     oe_runmake -C ${B} savedefconfig
     cp -a ${B}/defconfig ${DEPLOYDIR}
+}
+
+do_compile_append() {
+    config="${B}/.config"
+    if grep -q 'CONFIG_ARM_APPENDED_DTB=y' $config; then
+        oe_runmake -C ${B} dtbs
+    fi
+}
+
+do_install_append() {
+    config="${B}/.config"
+    if grep -q 'CONFIG_ARM_APPENDED_DTB=y' $config; then
+        oe_runmake -C ${B} DEPMOD=echo INSTALL_DTBS_PATH=${D}/boot/dtb dtbs_install
+    fi
 }
 
 FILES_${KERNEL_PACKAGE_NAME}-base += "${nonarch_base_libdir}/modules/${KERNEL_VERSION}/modules.builtin.modinfo "

--- a/meta-ledge-bsp/recipes-kernel/linux/linux-ledge/fragment-15-cleanup.config
+++ b/meta-ledge-bsp/recipes-kernel/linux/linux-ledge/fragment-15-cleanup.config
@@ -1,0 +1,30 @@
+#
+# CPU Core family selection
+#
+# CONFIG_ARCH_ALPINE is not set
+# CONFIG_ARCH_AT91 is not set
+# CONFIG_ARCH_AT91 is not set
+# CONFIG_ARCH_AXXIA is not set
+# CONFIG_ARCH_BCM is not set
+# CONFIG_ARCH_BERLIN is not set
+# CONFIG_ARCH_DIGICOLOR is not set
+# CONFIG_ARCH_EXYNOS is not set
+# CONFIG_ARCH_HIGHBANK is not set
+# CONFIG_ARCH_HISI is not set
+
+#
+# Cortex-A/Cortex-M asymmetric multiprocessing platforms
+#
+# CONFIG_ARCH_MEDIATEK is not set
+# CONFIG_ARCH_MESON is not set
+# CONFIG_ARCH_MVEBU is not set
+
+# CONFIG_ARCH_SIRF is not set
+# CONFIG_ARCH_ROCKCHIP is not set
+# CONFIG_ARCH_RENESAS is not set
+# CONFIG_ARCH_SOCFPGA is not set
+# CONFIG_PLAT_SPEAR is not set
+# CONFIG_ARCH_STI is not set
+# CONFIG_ARCH_TEGRA is not set
+# CONFIG_ARCH_U8500 is not set
+# CONFIG_ARCH_WM8850 is not set


### PR DESCRIPTION
The qemu images are used as reference to be used on several hardware
 and need to have all device tree for hardware supported.


Signed-off-by: Christophe Priouzeau <christophe.priouzeau@linaro.org>