### PR TITLE
KERNEL: put the result of dtbs on kernel-devicetree package

### DIFF
--- a/meta-ledge-bsp/recipes-kernel/linux/linux-ledge-common.inc
+++ b/meta-ledge-bsp/recipes-kernel/linux/linux-ledge-common.inc
@@ -79,6 +79,7 @@ do_install_append() {
     fi
 }
 
+FILES_${KERNEL_PACKAGE_NAME}-devicetree += "/${KERNEL_IMAGEDEST}/dtb/*.dtb"
 FILES_${KERNEL_PACKAGE_NAME}-base += "${nonarch_base_libdir}/modules/${KERNEL_VERSION}/modules.builtin.modinfo "
 
 # for debian purpose


### PR DESCRIPTION
Signed-off-by: Christophe Priouzeau <christophe.priouzeau@linaro.org>