### PR TITLE
bsp: remove dtb from firmware partition on am572x

### DIFF
--- a/meta-ledge-bsp/conf/machine/ledge-ti-am572x.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-ti-am572x.conf
@@ -35,9 +35,7 @@ FILES_${KERNEL_PACKAGE_NAME}-devicetree_append_ledge-ti-am572x += "/${KERNEL_IMA
 KERNEL_IMAGETYPES = "zImage"
 
 # WIC
-# U-Boot provided DTB does not work, use an external on for now, 
-# until we manage to embed the proper DTB 
-IMAGE_BOOT_FILES ?= "u-boot.img MLO am572x-idk.dtb"
+IMAGE_BOOT_FILES ?= "u-boot.img MLO"
 IMAGE_FSTYPES_remove += "tar.bz2 tar.xz ext4"
 IMAGE_FSTYPES += "wic"
 WKS_FILE += "ledge-ti-am572x.wks.in"

--- a/meta-ledge-bsp/recipes-kernel/linux/linux-ledge-common.inc
+++ b/meta-ledge-bsp/recipes-kernel/linux/linux-ledge-common.inc
@@ -92,10 +92,14 @@ do_install_append() {
         dtb_renamed=$(echo $dtb | cut -d':' -f 2 )
 
         if [ -f ${D}/boot/$dtb_orignal ]; then
-            mv ${D}/boot/$dtb_orignal ${D}/boot/$dtb_renamed
+            cd ${D}/boot/
+            ln -s $dtb_orignal $dtb_renamed
+           cd -
         fi
         if [ -f ${D}/boot/dtb/$dtb_orignal ]; then
-            mv ${D}/boot/dtb/$dtb_orignal ${D}/boot/dtb/$dtb_renamed
+            cd ${D}/boot/dtb/
+            ln -s $dtb_orignal $dtb_renamed
+            cd -
         fi
     done
 }


### PR DESCRIPTION
Since we install the dtbs on the ESP partition remove it from the
firmware one

Signed-off-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>