### PR TITLE
images: add initramfs image generation

### DIFF
--- a/meta-ledge-bsp/recipes-kernel/linux/linux-ledge-common.inc
+++ b/meta-ledge-bsp/recipes-kernel/linux/linux-ledge-common.inc
@@ -106,6 +106,7 @@ do_install_append() {
 
 FILES_${KERNEL_PACKAGE_NAME}-devicetree += "/${KERNEL_IMAGEDEST}/dtb"
 FILES_${KERNEL_PACKAGE_NAME}-base += "${nonarch_base_libdir}/modules/${KERNEL_VERSION}/modules.builtin.modinfo "
+INITRAMFS_IMAGE = "ledge-initramfs"
 
 # for debian purpose
 do_deploy_append() {

--- a/meta-ledge-bsp/wic/ledge-ti-am572x.wks.in
+++ b/meta-ledge-bsp/wic/ledge-ti-am572x.wks.in
@@ -3,4 +3,4 @@
 #
 part firmware --source bootimg-partition --fstype=vfat --label firmware --active --align 4 --size 16
 part /boot --source bootimg-efi --sourceparams="loader=kernel" --fstype=vfat --system-id 0xef --label bootfs --align 4 --size 64 --use-uuid  --include-path ${DEPLOY_DIR_IMAGE}/dtb
-part / --source rootfs --fstype=ext4 --label rootfs --align 4 --exclude-path boot/
+part / --source rootfs --fstype=ext4 --label rootfs --align 4 --fsuuid 6091b3a4-ce08-3020-93a6-f755a22ef03b --exclude-path boot/

--- a/meta-ledge-sw/recipes-samples/images/ledge-initramfs.bb
+++ b/meta-ledge-sw/recipes-samples/images/ledge-initramfs.bb
@@ -1,0 +1,25 @@
+DESCRIPTION = "Small ramdisk image for running tests (bootrr, etc)"
+
+PACKAGE_INSTALL = " \
+    busybox \
+    udev \
+    initramfs-module-rootfs \
+    initramfs-module-udev \
+"
+
+# Do not pollute the initrd image with rootfs features
+IMAGE_FEATURES = ""
+
+export IMAGE_BASENAME = "ledge-initramfs"
+IMAGE_LINGUAS = ""
+
+LICENSE = "MIT"
+
+IMAGE_FSTYPES = "${INITRAMFS_FSTYPES}"
+inherit core-image
+
+IMAGE_ROOTFS_SIZE = "8192"
+IMAGE_ROOTFS_EXTRA_SPACE = "0"
+
+# Disable installation of kernel and modules via packagegroup-core-boot
+NO_RECOMMENDATIONS = "1"


### PR DESCRIPTION
We need to provide a way for devices to mount our rootfs regardless of
the installation medium and partitions.
The currently used root=PARTUUID="uuid" is only working properly on
devices that support GPT. Although a pseudo uuid is generated for MBR,
we can't control it's value from WIC image generation tools and even if
we could, the generated uuid would differ from the GPT one.
Let's add filesystem UUID and an initramfs so we'll be able to mount root partitions
with root=UUID="uuid"

This patch only implements the initramfs generation and adds the proper
filesystem uuid to the WIC image for the TI board.
At the moment we add don't add kernel modules in the initramfs so the image is
2.7mb. This is expected to grow if we need modules in different devices

Signed-off-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>