### PR TITLE
CONF: Put initramfs configuration on machine

### DIFF
--- a/meta-ledge-bsp/conf/machine/ledge-qemuarm.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-qemuarm.conf
@@ -8,6 +8,7 @@ require conf/machine/include/ledge-qemu-common.inc
 
 PREFERRED_PROVIDER_virtual/kernel = "linux-ledge"
 PREFERRED_VERSION_linux-ledge = "mainline%"
+INITRAMFS_IMAGE = "ledge-initramfs"
 
 KERNEL_IMAGETYPE = "zImage"
 

--- a/meta-ledge-bsp/conf/machine/ledge-qemuarm64.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-qemuarm64.conf
@@ -9,6 +9,7 @@ require conf/machine/include/ledge-qemu-common.inc
 
 PREFERRED_PROVIDER_virtual/kernel = "linux-ledge"
 PREFERRED_VERSION_linux-ledge = "mainline%"
+INITRAMFS_IMAGE = "ledge-initramfs"
 
 KERNEL_IMAGETYPE = "Image"
 

--- a/meta-ledge-bsp/conf/machine/ledge-qemux86-64.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-qemux86-64.conf
@@ -4,6 +4,7 @@
 
 PREFERRED_PROVIDER_virtual/kernel = "linux-ledge"
 PREFERRED_VERSION_linux-ledge = "mainline%"
+INITRAMFS_IMAGE = "ledge-initramfs"
 
 PREFERRED_PROVIDER_virtual/xserver ?= "xserver-xorg"
 PREFERRED_PROVIDER_virtual/libgl ?= "mesa"

--- a/meta-ledge-bsp/conf/machine/ledge-stm32mp157c-dk2.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-stm32mp157c-dk2.conf
@@ -6,6 +6,7 @@ DEFAULTTUNE = "cortexa7thf-neon-vfpv4"
 
 PREFERRED_PROVIDER_virtual/kernel = "linux-ledge"
 PREFERRED_VERSION_linux-ledge = "mainline%"
+INITRAMFS_IMAGE = "ledge-initramfs"
 
 PACKAGECONFIG_pn_mesa = "${@bb.utils.filter('DISTRO_FEATURES', 'wayland ', d)} \
                    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'opengl egl gles gbm dri', '', d)} \

--- a/meta-ledge-bsp/conf/machine/ledge-synquacer.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-synquacer.conf
@@ -4,6 +4,7 @@ MACHINE_ENDIANNESS ?= "le"
 
 PREFERRED_PROVIDER_virtual/kernel = "linux-ledge"
 PREFERRED_VERSION_linux-ledge = "mainline%"
+INITRAMFS_IMAGE = "ledge-initramfs"
 
 PACKAGECONFIG_pn_mesa = "${@bb.utils.filter('DISTRO_FEATURES', 'wayland ', d)} \
                    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'opengl egl gles gbm dri', '', d)} \

--- a/meta-ledge-bsp/conf/machine/ledge-ti-am572x.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-ti-am572x.conf
@@ -4,6 +4,7 @@ MACHINEOVERRIDES .= ":am57xx-evm"
 
 PREFERRED_PROVIDER_virtual/kernel = "linux-ledge"
 PREFERRED_VERSION_linux-ledge = "mainline%"
+INITRAMFS_IMAGE = "ledge-initramfs"
 
 # Hack for GPU: do not use imx-gpu-viv
 PREFERRED_PROVIDER_virtual/egl_ledge-ti-am572x = "mesa"

--- a/meta-ledge-bsp/recipes-kernel/linux/linux-ledge-common.inc
+++ b/meta-ledge-bsp/recipes-kernel/linux/linux-ledge-common.inc
@@ -106,7 +106,6 @@ do_install_append() {
 
 FILES_${KERNEL_PACKAGE_NAME}-devicetree += "/${KERNEL_IMAGEDEST}/dtb"
 FILES_${KERNEL_PACKAGE_NAME}-base += "${nonarch_base_libdir}/modules/${KERNEL_VERSION}/modules.builtin.modinfo "
-INITRAMFS_IMAGE = "ledge-initramfs"
 
 # for debian purpose
 do_deploy_append() {


### PR DESCRIPTION
The INITRAMFS configuration MUST be associated to a machine.

Signed-off-by: Christophe Priouzeau <christophe.priouzeau@linaro.org>