### PR TITLE
CLASS: TSV: make nothing for initramfs image

### DIFF
--- a/meta-ledge-bsp/classes/tsv_fld_ledge.bbclass
+++ b/meta-ledge-bsp/classes/tsv_fld_ledge.bbclass
@@ -27,6 +27,10 @@ tsv_fld_template_for_ledge () {
     then
         return;
     fi
+    if [ "${PN}" = "${INITRAMFS_IMAGE}" ];
+    then
+        return;
+    fi
 
     cd ${DEPLOY_DIR_IMAGE};
 


### PR DESCRIPTION
In case of initramfs image, don't need to change the tsv.

Signed-off-by: Christophe Priouzeau <christophe.priouzeau@linaro.org>