### PR TITLE
images: Use initramfs

### DIFF
--- a/meta-ledge-bsp/recipes-kernel/linux/linux-ledge/0006-efi-libstub-Fix-kernel-command-line.patch
+++ b/meta-ledge-bsp/recipes-kernel/linux/linux-ledge/0006-efi-libstub-Fix-kernel-command-line.patch
@@ -1,0 +1,197 @@
+From 7595a607c3548132e0fbec34a8b69432321a7fad Mon Sep 17 00:00:00 2001
+From: Ilias Apalodimas <ilias.apalodimas@linaro.org>
+Date: Fri, 24 Jan 2020 17:57:08 +0200
+Subject: [PATCH v2] efi: libstub: Fix kernel command line
+
+On our parsing we never included the kernel command line for anything
+apart from efi= related args. As a result adding initrd= on the firmware
+works fine, but fails if it's specified in the kernel command-line args.
+Also the current code doesn't fully respect CONFIG_CMDLINE_FORCE.
+Provide a function that will concatenate the efi cmd line and kernel cmd
+line when appropriate.
+If CONFIG_CMDLINE_EXTEND is selected command line will be extended.
+If CONFIG_CMDLINE_FORCE is selected the .config command line will be
+forced regardless.
+If CONFIG_CMDLINE_FROM_BOOTLOADER is selected only the firmware
+arguments will be passed, unless empty. In that case we'll use whatever
+the kernel built-in cmd line provides.
+
+Signed-off-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>
+---
+Changes since v1:
+- Free memory properly on fails
+
+ drivers/firmware/efi/libstub/arm-stub.c | 84 +++++++++++++++++++------
+ 1 file changed, 66 insertions(+), 18 deletions(-)
+
+diff --git a/drivers/firmware/efi/libstub/arm-stub.c b/drivers/firmware/efi/libstub/arm-stub.c
+index 817237ce2420..656abbc7d1e8 100644
+--- a/drivers/firmware/efi/libstub/arm-stub.c
++++ b/drivers/firmware/efi/libstub/arm-stub.c
+@@ -90,6 +90,44 @@ void install_memreserve_table(efi_system_table_t *sys_table_arg)
+ 		pr_efi_err(sys_table_arg, "Failed to install memreserve config table!\n");
+ }
+ 
++char *concat_cmd_lines(efi_system_table_t *sys_table_arg, char *efi_cmd_line)
++{
++	char *cmdline;
++	int efi_line_len = strlen(efi_cmd_line);
++	int tot_len = efi_line_len;
++	efi_status_t status;
++
++	/* Ignore the kernel cmdline */
++	if (IS_ENABLED(CONFIG_CMDLINE_FROM_BOOTLOADER) && efi_line_len)
++		return efi_cmd_line;
++
++	if (IS_ENABLED(CONFIG_CMDLINE_EXTEND)) {
++		/* white space + NUL termination */
++		tot_len += strlen(CONFIG_CMDLINE) + 2;
++	} else if (IS_ENABLED(CONFIG_CMDLINE_FORCE) ||
++		 (IS_ENABLED(CONFIG_CMDLINE_FROM_BOOTLOADER) && !efi_line_len)) {
++		tot_len = strlen(CONFIG_CMDLINE) + 1;
++		efi_line_len = 0;
++	} else {
++		return NULL;
++	}
++
++	status = efi_call_early(allocate_pool, EFI_LOADER_DATA, tot_len,
++				(void **)&cmdline);
++	if (status != EFI_SUCCESS)
++		return NULL;
++
++	if (efi_line_len) {
++		memcpy(cmdline, efi_cmd_line, efi_line_len);
++		*(cmdline + efi_line_len) = ' ';
++		efi_line_len++;
++	}
++
++	memcpy(cmdline + efi_line_len, CONFIG_CMDLINE,
++	       strlen(CONFIG_CMDLINE) + 1);
++
++	return cmdline;
++}
+ 
+ /*
+  * This function handles the architcture specific differences between arm and
+@@ -110,7 +148,7 @@ efi_status_t handle_kernel_image(efi_system_table_t *sys_table,
+  * for both archictectures, with the arch-specific code provided in the
+  * handle_kernel_image() function.
+  */
+-unsigned long efi_entry(void *handle, efi_system_table_t *sys_table,
++unsigned long efi_entry(void *handle, efi_system_table_t *sys_table_arg,
+ 			       unsigned long *image_addr)
+ {
+ 	efi_loaded_image_t *image;
+@@ -122,14 +160,16 @@ unsigned long efi_entry(void *handle, efi_system_table_t *sys_table,
+ 	u64 initrd_size = 0;
+ 	unsigned long fdt_addr = 0;  /* Original DTB */
+ 	unsigned long fdt_size = 0;
+-	char *cmdline_ptr = NULL;
+-	int cmdline_size = 0;
++	char *efi_cmdline_ptr = NULL;
++	char *full_cmdline_ptr = NULL; /* Include kernel cmdline */
++	int efi_cmdline_size = 0;
+ 	unsigned long new_fdt_addr;
+ 	efi_guid_t loaded_image_proto = LOADED_IMAGE_PROTOCOL_GUID;
+ 	unsigned long reserve_addr = 0;
+ 	unsigned long reserve_size = 0;
+ 	enum efi_secureboot_mode secure_boot;
+ 	struct screen_info *si;
++	efi_system_table_t *sys_table = sys_table_arg;
+ 
+ 	/* Check if we were booted by the EFI firmware */
+ 	if (sys_table->hdr.signature != EFI_SYSTEM_TABLE_SIGNATURE)
+@@ -162,19 +202,20 @@ unsigned long efi_entry(void *handle, efi_system_table_t *sys_table,
+ 	 * protocol. We are going to copy the command line into the
+ 	 * device tree, so this can be allocated anywhere.
+ 	 */
+-	cmdline_ptr = efi_convert_cmdline(sys_table, image, &cmdline_size);
+-	if (!cmdline_ptr) {
++	efi_cmdline_ptr = efi_convert_cmdline(sys_table, image,
++					      &efi_cmdline_size);
++	if (!efi_cmdline_ptr) {
+ 		pr_efi_err(sys_table, "getting command line via LOADED_IMAGE_PROTOCOL\n");
+ 		goto fail;
+ 	}
+ 
+-	if (IS_ENABLED(CONFIG_CMDLINE_EXTEND) ||
+-	    IS_ENABLED(CONFIG_CMDLINE_FORCE) ||
+-	    cmdline_size == 0)
+-		efi_parse_options(CONFIG_CMDLINE);
++	full_cmdline_ptr = concat_cmd_lines(sys_table, efi_cmdline_ptr);
++	if (!full_cmdline_ptr) {
++		pr_efi_err(sys_table, "Failed to get a proper commandline\n");
++		goto fail_free_cmdline;
++	}
+ 
+-	if (!IS_ENABLED(CONFIG_CMDLINE_FORCE) && cmdline_size > 0)
+-		efi_parse_options(cmdline_ptr);
++	efi_parse_options(full_cmdline_ptr);
+ 
+ 	pr_efi(sys_table, "Booting Linux Kernel...\n");
+ 
+@@ -186,7 +227,7 @@ unsigned long efi_entry(void *handle, efi_system_table_t *sys_table,
+ 				     dram_base, image);
+ 	if (status != EFI_SUCCESS) {
+ 		pr_efi_err(sys_table, "Failed to relocate kernel\n");
+-		goto fail_free_cmdline;
++		goto fail_free_screeninfo;
+ 	}
+ 
+ 	efi_retrieve_tpm2_eventlog(sys_table);
+@@ -203,10 +244,10 @@ unsigned long efi_entry(void *handle, efi_system_table_t *sys_table,
+ 	 */
+ 	if (!IS_ENABLED(CONFIG_EFI_ARMSTUB_DTB_LOADER) ||
+ 	     secure_boot != efi_secureboot_mode_disabled) {
+-		if (strstr(cmdline_ptr, "dtb="))
++		if (strstr(full_cmdline_ptr, "dtb="))
+ 			pr_efi(sys_table, "Ignoring DTB from command line.\n");
+ 	} else {
+-		status = handle_cmdline_files(sys_table, image, cmdline_ptr,
++		status = handle_cmdline_files(sys_table, image, full_cmdline_ptr,
+ 					      "dtb=",
+ 					      ~0UL, &fdt_addr, &fdt_size);
+ 
+@@ -228,7 +269,7 @@ unsigned long efi_entry(void *handle, efi_system_table_t *sys_table,
+ 	if (!fdt_addr)
+ 		pr_efi(sys_table, "Generating empty DTB\n");
+ 
+-	status = handle_cmdline_files(sys_table, image, cmdline_ptr, "initrd=",
++	status = handle_cmdline_files(sys_table, image, full_cmdline_ptr, "initrd=",
+ 				      efi_get_max_initrd_addr(dram_base,
+ 							      *image_addr),
+ 				      (unsigned long *)&initrd_addr,
+@@ -261,10 +302,14 @@ unsigned long efi_entry(void *handle, efi_system_table_t *sys_table,
+ 
+ 	install_memreserve_table(sys_table);
+ 
++	/* done with the full cmd line ptr */
++	if (full_cmdline_ptr != efi_cmdline_ptr)
++		efi_call_early(free_pool, (void *)full_cmdline_ptr);
++
+ 	new_fdt_addr = fdt_addr;
+ 	status = allocate_new_fdt_and_exit_boot(sys_table, handle,
+ 				&new_fdt_addr, efi_get_max_fdt_addr(dram_base),
+-				initrd_addr, initrd_size, cmdline_ptr,
++				initrd_addr, initrd_size, efi_cmdline_ptr,
+ 				fdt_addr, fdt_size);
+ 
+ 	/*
+@@ -283,9 +328,12 @@ unsigned long efi_entry(void *handle, efi_system_table_t *sys_table,
+ fail_free_image:
+ 	efi_free(sys_table, image_size, *image_addr);
+ 	efi_free(sys_table, reserve_size, reserve_addr);
+-fail_free_cmdline:
++fail_free_screeninfo:
+ 	free_screen_info(sys_table, si);
+-	efi_free(sys_table, cmdline_size, (unsigned long)cmdline_ptr);
++	if (full_cmdline_ptr != efi_cmdline_ptr)
++		efi_call_early(free_pool, (void *)full_cmdline_ptr);
++fail_free_cmdline:
++	efi_free(sys_table, efi_cmdline_size, (unsigned long)efi_cmdline_ptr);
+ fail:
+ 	return EFI_ERROR;
+ }
+-- 
+2.25.0
+

--- a/meta-ledge-bsp/recipes-kernel/linux/linux-ledge/fragment-13-cmdline.config
+++ b/meta-ledge-bsp/recipes-kernel/linux/linux-ledge/fragment-13-cmdline.config
@@ -1,3 +1,6 @@
 # cmdline
+CONFIG_ARM_ATAG_DTB_COMPAT=y
+CONFIG_ARM_ATAG_DTB_COMPAT_CMDLINE_EXTEND=y
 CONFIG_CMDLINE_BOOL=y
-CONFIG_CMDLINE="root=PARTLABEL=rootfs console=ttyS0,115200 console=ttyAMA0,115200"
+CONFIG_CMDLINE_EXTEND=y
+CONFIG_CMDLINE="rootwait initrd=/ledge-initramfs.rootfs.cpio.gz root=UUID=6091b3a4-ce08-3020-93a6-f755a22ef03b console=ttyS2,115200 console=ttyS0,115200 console=ttyAMA0,115200"

--- a/meta-ledge-bsp/recipes-kernel/linux/linux-ledge_mainline.bb
+++ b/meta-ledge-bsp/recipes-kernel/linux/linux-ledge_mainline.bb
@@ -28,6 +28,7 @@ SRC_URI += " \
     file://0003-KERNEL-stm32mp157-dts-add-ftpm-support.patch \
     file://0004-op-tee-shm.patch \
     file://0005-op-tee-multi-page-shm.patch \
+    file://0006-efi-libstub-Fix-kernel-command-line.patch \
     "
 
 PV = "mainline-5.3"

--- a/meta-ledge-bsp/wic/ledge-ti-am572x.wks.in
+++ b/meta-ledge-bsp/wic/ledge-ti-am572x.wks.in
@@ -2,5 +2,5 @@
 # long-description: Creates a partitioned SD card image
 #
 part firmware --source bootimg-partition --fstype=vfat --label firmware --active --align 4 --size 16
-part /boot --source bootimg-efi --sourceparams="loader=kernel" --fstype=vfat --system-id 0xef --label bootfs --align 4 --size 64 --use-uuid  --include-path ${DEPLOY_DIR_IMAGE}/dtb
+part /boot --source bootimg-efi --sourceparams="loader=kernel" --fstype=vfat --system-id 0xef --label bootfs --align 4 --use-uuid --include-path "${DEPLOY_DIR_IMAGE}/dtb ${DEPLOY_DIR_IMAGE}/ledge-initramfs.rootfs.cpio.gz"
 part / --source rootfs --fstype=ext4 --label rootfs --align 4 --fsuuid 6091b3a4-ce08-3020-93a6-f755a22ef03b --exclude-path boot/

--- a/meta-ledge-sw/recipes-samples/images/ledge-initramfs.bb
+++ b/meta-ledge-sw/recipes-samples/images/ledge-initramfs.bb
@@ -2,7 +2,6 @@ DESCRIPTION = "Small ramdisk image for running tests (bootrr, etc)"
 
 PACKAGE_INSTALL = " \
     busybox \
-    udev \
     initramfs-module-rootfs \
     initramfs-module-udev \
 "
@@ -10,7 +9,7 @@ PACKAGE_INSTALL = " \
 # Do not pollute the initrd image with rootfs features
 IMAGE_FEATURES = ""
 
-export IMAGE_BASENAME = "ledge-initramfs"
+export IMAGE_NAME = "ledge-initramfs"
 IMAGE_LINGUAS = ""
 
 LICENSE = "MIT"


### PR DESCRIPTION
Fix kernel parsing for initrd= from the default cmd-line and
add a CONFIG_CMDLINE with initramfs and UUID.
This will aloow our distro to boot regardless of the bootloader as long
as the partition uuid is set correctly

Signed-off-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>