### PR TITLE
kernel: fix initrd parsing from kernel commandline

### DIFF
--- a/meta-ledge-bsp/recipes-kernel/linux/linux-ledge/0006-efi-libstub-Fix-kernel-command-line.patch
+++ b/meta-ledge-bsp/recipes-kernel/linux/linux-ledge/0006-efi-libstub-Fix-kernel-command-line.patch
@@ -1,7 +1,7 @@
-From 7595a607c3548132e0fbec34a8b69432321a7fad Mon Sep 17 00:00:00 2001
+From bc7d3d78fc4f8c2c3beec67f9658ca980f53e2eb Mon Sep 17 00:00:00 2001
 From: Ilias Apalodimas <ilias.apalodimas@linaro.org>
 Date: Fri, 24 Jan 2020 17:57:08 +0200
-Subject: [PATCH v2] efi: libstub: Fix kernel command line
+Subject: [PATCH] efi: libstub: Fix kernel command line
 
 On our parsing we never included the kernel command line for anything
 apart from efi= related args. As a result adding initrd= on the firmware
@@ -18,17 +18,14 @@ the kernel built-in cmd line provides.
 
 Signed-off-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>
 ---
-Changes since v1:
-- Free memory properly on fails
-
- drivers/firmware/efi/libstub/arm-stub.c | 84 +++++++++++++++++++------
- 1 file changed, 66 insertions(+), 18 deletions(-)
+ drivers/firmware/efi/libstub/arm-stub.c | 87 ++++++++++++++++++++-----
+ 1 file changed, 69 insertions(+), 18 deletions(-)
 
 diff --git a/drivers/firmware/efi/libstub/arm-stub.c b/drivers/firmware/efi/libstub/arm-stub.c
-index 817237ce2420..656abbc7d1e8 100644
+index 817237ce2420..a68609670992 100644
 --- a/drivers/firmware/efi/libstub/arm-stub.c
 +++ b/drivers/firmware/efi/libstub/arm-stub.c
-@@ -90,6 +90,44 @@ void install_memreserve_table(efi_system_table_t *sys_table_arg)
+@@ -90,6 +90,47 @@ void install_memreserve_table(efi_system_table_t *sys_table_arg)
  		pr_efi_err(sys_table_arg, "Failed to install memreserve config table!\n");
  }
  
@@ -51,7 +48,10 @@ index 817237ce2420..656abbc7d1e8 100644
 +		tot_len = strlen(CONFIG_CMDLINE) + 1;
 +		efi_line_len = 0;
 +	} else {
-+		return NULL;
++		/* Not all architectures support CONFIG_CMDLINE_* treat
++		 * everything else as extend
++		 */
++		tot_len += strlen(CONFIG_CMDLINE) + 2;
 +	}
 +
 +	status = efi_call_early(allocate_pool, EFI_LOADER_DATA, tot_len,
@@ -73,7 +73,7 @@ index 817237ce2420..656abbc7d1e8 100644
  
  /*
   * This function handles the architcture specific differences between arm and
-@@ -110,7 +148,7 @@ efi_status_t handle_kernel_image(efi_system_table_t *sys_table,
+@@ -110,7 +151,7 @@ efi_status_t handle_kernel_image(efi_system_table_t *sys_table,
   * for both archictectures, with the arch-specific code provided in the
   * handle_kernel_image() function.
   */
@@ -82,7 +82,7 @@ index 817237ce2420..656abbc7d1e8 100644
  			       unsigned long *image_addr)
  {
  	efi_loaded_image_t *image;
-@@ -122,14 +160,16 @@ unsigned long efi_entry(void *handle, efi_system_table_t *sys_table,
+@@ -122,14 +163,16 @@ unsigned long efi_entry(void *handle, efi_system_table_t *sys_table,
  	u64 initrd_size = 0;
  	unsigned long fdt_addr = 0;  /* Original DTB */
  	unsigned long fdt_size = 0;
@@ -101,7 +101,7 @@ index 817237ce2420..656abbc7d1e8 100644
  
  	/* Check if we were booted by the EFI firmware */
  	if (sys_table->hdr.signature != EFI_SYSTEM_TABLE_SIGNATURE)
-@@ -162,19 +202,20 @@ unsigned long efi_entry(void *handle, efi_system_table_t *sys_table,
+@@ -162,19 +205,20 @@ unsigned long efi_entry(void *handle, efi_system_table_t *sys_table,
  	 * protocol. We are going to copy the command line into the
  	 * device tree, so this can be allocated anywhere.
  	 */
@@ -130,7 +130,7 @@ index 817237ce2420..656abbc7d1e8 100644
  
  	pr_efi(sys_table, "Booting Linux Kernel...\n");
  
-@@ -186,7 +227,7 @@ unsigned long efi_entry(void *handle, efi_system_table_t *sys_table,
+@@ -186,7 +230,7 @@ unsigned long efi_entry(void *handle, efi_system_table_t *sys_table,
  				     dram_base, image);
  	if (status != EFI_SUCCESS) {
  		pr_efi_err(sys_table, "Failed to relocate kernel\n");
@@ -139,7 +139,7 @@ index 817237ce2420..656abbc7d1e8 100644
  	}
  
  	efi_retrieve_tpm2_eventlog(sys_table);
-@@ -203,10 +244,10 @@ unsigned long efi_entry(void *handle, efi_system_table_t *sys_table,
+@@ -203,10 +247,10 @@ unsigned long efi_entry(void *handle, efi_system_table_t *sys_table,
  	 */
  	if (!IS_ENABLED(CONFIG_EFI_ARMSTUB_DTB_LOADER) ||
  	     secure_boot != efi_secureboot_mode_disabled) {
@@ -152,7 +152,7 @@ index 817237ce2420..656abbc7d1e8 100644
  					      "dtb=",
  					      ~0UL, &fdt_addr, &fdt_size);
  
-@@ -228,7 +269,7 @@ unsigned long efi_entry(void *handle, efi_system_table_t *sys_table,
+@@ -228,7 +272,7 @@ unsigned long efi_entry(void *handle, efi_system_table_t *sys_table,
  	if (!fdt_addr)
  		pr_efi(sys_table, "Generating empty DTB\n");
  
@@ -161,7 +161,7 @@ index 817237ce2420..656abbc7d1e8 100644
  				      efi_get_max_initrd_addr(dram_base,
  							      *image_addr),
  				      (unsigned long *)&initrd_addr,
-@@ -261,10 +302,14 @@ unsigned long efi_entry(void *handle, efi_system_table_t *sys_table,
+@@ -261,10 +305,14 @@ unsigned long efi_entry(void *handle, efi_system_table_t *sys_table,
  
  	install_memreserve_table(sys_table);
  
@@ -177,7 +177,7 @@ index 817237ce2420..656abbc7d1e8 100644
  				fdt_addr, fdt_size);
  
  	/*
-@@ -283,9 +328,12 @@ unsigned long efi_entry(void *handle, efi_system_table_t *sys_table,
+@@ -283,9 +331,12 @@ unsigned long efi_entry(void *handle, efi_system_table_t *sys_table,
  fail_free_image:
  	efi_free(sys_table, image_size, *image_addr);
  	efi_free(sys_table, reserve_size, reserve_addr);


### PR DESCRIPTION
On the previous patch we didn't accept and extended commandline if
_EXTEND was not configured. Unfortunately the kernel treat
CONFIG_CMDLINE_* per architecture so EXTEND is not present on armv8.
Change the approach and only respect _FORCE arguemens, extend the
cmdline for other configurations

Signed-off-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>