### PR TITLE
adjust ledge-x86-64 to bootfs method

### DIFF
--- a/meta-ledge-bsp/classes/image_types-ledgebootfs.bbclass
+++ b/meta-ledge-bsp/classes/image_types-ledgebootfs.bbclass
@@ -58,7 +58,20 @@ IMAGE_CMD_ledgebootfs () {
     mcopy -i ${LEDGE_BOOTFS_NAME} -s ${DEPLOY_DIR_IMAGE}/dtb/* ::/dtb/
     # put initramfs
     mcopy -i ${LEDGE_BOOTFS_NAME} -s ${DEPLOY_DIR_IMAGE}/ledge-initramfs.rootfs.cpio.gz ::/
+}
 
+IMAGE_CMD_ledgebootfs_append_x86-64() {
+        # LEDGE: Pass initrd as bootloader parameter until
+        # kernel parameter initrd= with the uefi loader will be
+        # implemented for x86 and kernel patches are merged to mainline.
+
+	echo "bootx64.efi initrd=ledge-initramfs.rootfs.cpio.gz " > startup.nsh
+	mcopy -i ${LEDGE_BOOTFS_NAME} -s startup.nsh ::/
+	rm startup.nsh
+}
+
+# Final stage - compress and create symlinks
+IMAGE_CMD_ledgebootfs_append() {
     (cd ${IMGDEPLOYDIR};ln -sf ${IMAGE_NAME}.bootfs.vfat ${IMAGE_LINK_NAME}.bootfs.vfat)
     (cd ${IMGDEPLOYDIR};gzip -f -9 -c ${IMAGE_NAME}.bootfs.vfat > ${IMAGE_NAME}.bootfs.vfat.gz)
     (cd ${IMGDEPLOYDIR};cp ${IMAGE_NAME}.bootfs.vfat.gz ${IMAGE_LINK_NAME}.bootfs.vfat.gz)

--- a/meta-ledge-bsp/conf/machine/ledge-qemux86-64.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-qemux86-64.conf
@@ -38,6 +38,7 @@ MACHINE_FEATURES += "pcbios efi"
 
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS += "v86d"
 EXTRA_IMAGEDEPENDS += " ovmf "
+EXTRA_IMAGEDEPENDS += " qemu-ledge-run "
 
 MACHINE_EXTRA_RRECOMMENDS = "kernel-module-snd-ens1370 kernel-module-snd-rawmidi"
 
@@ -49,12 +50,12 @@ module_conf_uvesafb = "options uvesafb mode_option=${UVESA_MODE}"
 do_image_wic[depends] += "syslinux:do_populate_sysroot syslinux-native:do_populate_sysroot mtools-native:do_populate_sysroot dosfstools-native:do_populate_sysroot"
 IMAGE_FSTYPES_remove += "tar.bz2 tar.xz ext4"
 IMAGE_FSTYPES += "wic"
-WKS_FILE += "ledge-kernel-uefi-x86.wks.in"
+WKS_FILE += "ledge-kernel-uefi.wks.in"
 
 # For runqemu
 QB_SYSTEM_NAME = "qemu-system-x86_64"
 QB_MACHINE = ""
-QB_CPU = ""
+QB_CPU = "-cpu host -enable-kvm"
 QB_APPEND =  "-device virtio-rng-pci"
 QB_ROOTFS_OPT = " -drive file=@ROOTFS@,id=disk0,format=raw,bootindex=0"
 QB_DRIVE_TYPE = "/dev/hd"

--- a/meta-ledge-bsp/recipes-bsp/qemu-ledge-run/files/ledge-qemux86_run.sh
+++ b/meta-ledge-bsp/recipes-bsp/qemu-ledge-run/files/ledge-qemux86_run.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+DISK="$1"
+OVMF="$2"
+OVMF_FORMAT="${OVMF_FORMAT:-raw}"
+QEMU="${QEMU:-qemu-system-x86_64}"
+
+${QEMU} \
+	-cpu host -enable-kvm -nographic -net nic,model=virtio,macaddr=DE:AD:BE:EF:36:03 -net tap -m 1024 -monitor none \
+	-drive file=${DISK},id=hd,format=raw \
+	-drive if=pflash,format=${OVMF_FORMAT},file=${OVMF} \
+	-m 4096 -serial mon:stdio -show-cursor -object rng-random,filename=/dev/urandom,id=rng0 -device virtio-rng-pci,rng=rng0

--- a/meta-ledge-bsp/recipes-bsp/qemu-ledge-run/qemu-ledge-run.bb
+++ b/meta-ledge-bsp/recipes-bsp/qemu-ledge-run/qemu-ledge-run.bb
@@ -1,0 +1,27 @@
+SECTION = "tools"
+
+LICENSE = "GPLv2+"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425610833a22dbe6"
+
+S = "${WORKDIR}/git"
+PR = "r1"
+
+inherit deploy
+
+ALLOW_EMPTY_${PN} = "1"
+
+SRC_URI_append_x86-64 = " file://ledge-qemux86_run.sh;apply=no"
+
+do_deploy () {
+
+}
+
+do_deploy_append_ledge-qemux86-64() {
+	cp ${WORKDIR}/ledge-qemux86_run.sh ${DEPLOYDIR}/ledge-qemux86_run.sh
+	chmod +x ${DEPLOYDIR}/ledge-qemux86_run.sh
+}
+
+addtask deploy before do_build after do_compile
+
+DEPENDS = "dtc-native"
+PACKAGE_ARCH = "${MACHINE_ARCH}"

--- a/meta-ledge-bsp/wic/ledge-kernel-uefi-x86.wks.in
+++ b/meta-ledge-bsp/wic/ledge-kernel-uefi-x86.wks.in
@@ -1,3 +1,0 @@
-bootloader  --ptable gpt --timeout=0  --append="rootwait"
-part /boot --source bootimg-efi --sourceparams="loader=kernel" --fstype=vfat --label bootfs --active --align 4 --use-uuid --include-path "${DEPLOY_DIR_IMAGE}/dtb ${DEPLOY_DIR_IMAGE}/ledge-initramfs.rootfs.cpio.gz ${DEPLOY_DIR_IMAGE}/startup.nsh"
-part / --source rootfs --fstype=ext4 --label rootfs --align 4 --fsuuid 6091b3a4-ce08-3020-93a6-f755a22ef03b --exclude-path boot/ --use-label


### PR DESCRIPTION
1. move bootloaded params to bootfs creation.
2. use qemu -cpu host -enable-kvm instead of coreduo.
3. put simple script to run wic images.

new issue: ovmf which we build inside build can not handle initrd kernel
parameter. Upgrade is needed.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>