### PR TITLE
linux-ledge: change cert image extension name

### DIFF
--- a/meta-ledge-bsp/conf/machine/ledge-qemuarm.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-qemuarm.conf
@@ -55,7 +55,7 @@ QB_CPU = "-cpu cortex-a15"
 QB_MEM = "-m 1024"
 QB_KERNEL_CMDLINE_APPEND = "console=ttyAMA0,115200 console=tty"
 # Add the 'virtio-rng-pci' device otherwise the guest may run out of entropy
-QB_OPT_APPEND = "-show-cursor -device virtio-rng-pci -monitor null -nographic -d unimp -semihosting-config enable,target=native -bios bl1.bin -dtb ledge-qemuarm.dtb -drive id=disk1,file=ledge-kernel-uefi-certs.ext4,if=none,format=raw -device virtio-blk-device,drive=disk1"
+QB_OPT_APPEND = "-show-cursor -device virtio-rng-pci -monitor null -nographic -d unimp -semihosting-config enable,target=native -bios bl1.bin -dtb ledge-qemuarm.dtb -drive id=disk1,file=ledge-kernel-uefi-certs.ext4.img,if=none,format=raw -device virtio-blk-device,drive=disk1"
 QB_SERIAL_OPT = "-device virtio-serial-device -chardev null,id=virtcon -device virtconsole,chardev=virtcon"
 QB_DRIVE_TYPE = "/dev/vdb"
 QB_ROOTFS_OPT = "-drive id=disk0,file=@ROOTFS@,if=none,format=raw -device virtio-blk-device,drive=disk0"

--- a/meta-ledge-bsp/conf/machine/ledge-qemuarm64.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-qemuarm64.conf
@@ -55,7 +55,7 @@ QB_MACHINE = "-machine virt,secure=on"
 QB_CPU = "-cpu cortex-a57"
 QB_KERNEL_CMDLINE_APPEND = "console=ttyAMA0,115200 console=tty"
 # Add the 'virtio-rng-pci' device otherwise the guest may run out of entropy
-QB_OPT_APPEND = "-show-cursor -device virtio-rng-pci -monitor null -nographic -d unimp -semihosting-config enable,target=native -bios bl1.bin -dtb ledge-qemuarm64.dtb -drive id=disk1,file=ledge-kernel-uefi-certs.ext4,if=none,format=raw -device virtio-blk-device,drive=disk1"
+QB_OPT_APPEND = "-show-cursor -device virtio-rng-pci -monitor null -nographic -d unimp -semihosting-config enable,target=native -bios bl1.bin -dtb ledge-qemuarm64.dtb -drive id=disk1,file=ledge-kernel-uefi-certs.ext4.img,if=none,format=raw -device virtio-blk-device,drive=disk1"
 QB_SERIAL_OPT = "-device virtio-serial-device -chardev null,id=virtcon -device virtconsole,chardev=virtcon"
 QB_DRIVE_TYPE = "/dev/vdb"
 QB_ROOTFS_OPT = "-drive id=disk0,file=@ROOTFS@,if=none,format=raw -device virtio-blk-device,drive=disk0"

--- a/meta-ledge-bsp/recipes-kernel/linux/linux-ledge-sign.inc
+++ b/meta-ledge-bsp/recipes-kernel/linux/linux-ledge-sign.inc
@@ -29,7 +29,7 @@ do_install_append() {
 	${STAGING_DIR_NATIVE}/sbin/mkfs.ext4 certimage.ext4 -d ./certimage
 
 	install -d ${DEPLOY_DIR_IMAGE}
-	install -m 0644 certimage.ext4 ${DEPLOY_DIR_IMAGE}/ledge-kernel-uefi-certs.ext4
+	install -m 0644 certimage.ext4 ${DEPLOY_DIR_IMAGE}/ledge-kernel-uefi-certs.ext4.img
 
 	rm -rf ./certimage kernel.hash certimage.ext4
 }


### PR DESCRIPTION
IMAGE_FS_TYPES_remove +="ext4" deletes all images with
ext4 extentions. We need to rename this image.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>