### PR TITLE
fix sstate handling of cert ext4 image

### DIFF
--- a/meta-ledge-bsp/recipes-kernel/linux/linux-ledge-sign.inc
+++ b/meta-ledge-bsp/recipes-kernel/linux/linux-ledge-sign.inc
@@ -7,7 +7,7 @@ SRC_URI_append = " file://uefi-certificates/PK.auth "
 
 inherit kernel siteinfo
 
-do_install_append() {
+do_deploy_append() {
        # WIC image creates efi partition with ${D}/boot/efi/boot/${KERNEL_EFI_IMAGE}
        # @todo: rethink how to sign kernel image after wic chooses one.
        for img in bzImage zImage Image; do
@@ -28,8 +28,7 @@ do_install_append() {
 	truncate -s 4M certimage.ext4
 	${STAGING_DIR_NATIVE}/sbin/mkfs.ext4 certimage.ext4 -d ./certimage
 
-	install -d ${DEPLOY_DIR_IMAGE}
-	install -m 0644 certimage.ext4 ${DEPLOY_DIR_IMAGE}/ledge-kernel-uefi-certs.ext4.img
+	install -m 0644 certimage.ext4 ${DEPLOYDIR}/ledge-kernel-uefi-certs.ext4.img
 
 	rm -rf ./certimage kernel.hash certimage.ext4
 }


### PR DESCRIPTION
Previously the ledge-kernel-uefi-certs.ext4.img file was create and
deployed directly to the tmp-rpb-glibc/deploy/image/*/ dir.

This means it is  not saved in sstate and won't be present in using sstate
on subsequent runs.

This change aligns more with std OE practice and allows sstate to work.

Signed-off-by: Bill Mills <wmills@ti.com>