### PR TITLE
U-Boot: TI: Allow distro_bootcmd to boot more am572x based SoCs

### DIFF
--- a/meta-ledge-bsp/recipes-bsp/u-boot/u-boot-ledge/0001-u-boot-ti-am572x-enable-boot_distrocmd.patch
+++ b/meta-ledge-bsp/recipes-bsp/u-boot/u-boot-ledge/0001-u-boot-ti-am572x-enable-boot_distrocmd.patch
@@ -1,26 +1,28 @@
-From 4a15a7342dbdb00572d785f66c624b064a2adfd7 Mon Sep 17 00:00:00 2001
+From 849817d498698de8c231dffd8f27099c090bdbe1 Mon Sep 17 00:00:00 2001
 From: Ilias Apalodimas <ilias.apalodimas@linaro.org>
-Date: Fri, 17 Jan 2020 12:13:27 +0200
+Date: Thu, 5 Mar 2020 21:42:46 +0200
 Subject: [PATCH] u-boot: ti: am572x enable boot_distrocmd
 
 Signed-off-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>
 ---
- include/configs/am57xx_evm.h      |  6 ++++++
- include/configs/ti_omap5_common.h |  1 +
- include/environment/ti/boot.h     | 10 +++++++++-
- 3 files changed, 16 insertions(+), 1 deletion(-)
+ include/configs/am57xx_evm.h      | 8 ++++++++
+ include/configs/ti_omap5_common.h | 1 +
+ include/environment/ti/boot.h     | 8 ++++++++
+ 3 files changed, 17 insertions(+)
 
 diff --git a/include/configs/am57xx_evm.h b/include/configs/am57xx_evm.h
-index fea9300a67de..246f862ff811 100644
+index fea9300a67de..8517344a57d4 100644
 --- a/include/configs/am57xx_evm.h
 +++ b/include/configs/am57xx_evm.h
-@@ -49,6 +49,12 @@
+@@ -49,6 +49,14 @@
  #endif
  #endif
  
 +#ifdef CONFIG_DISTRO_DEFAULTS
 +#define BOOT_TARGET_DEVICES(func) \
-+        func(MMC, mmc, 0) \
++	func(MMC, mmc, 0) \
++	func(MMC, mmc, 1) \
++	func(USB, usb, 0)
 +
 +#include <config_distro_bootcmd.h>
 +#endif
@@ -40,27 +42,10 @@ index de0a6af2fdc9..d44690fb3a1d 100644
  /*
   * SPL related defines.  The Public RAM memory map the ROM defines the
 diff --git a/include/environment/ti/boot.h b/include/environment/ti/boot.h
-index 6313f3e328a0..227448c3c3cd 100644
+index 523c8fc4fe9a..ffa12ed69a43 100644
 --- a/include/environment/ti/boot.h
 +++ b/include/environment/ti/boot.h
-@@ -102,9 +102,15 @@
- 	"echo Booting into fastboot ...; " \
- 	"fastboot " __stringify(CONFIG_FASTBOOT_USB_DEV) "; "
- 
-+#ifdef CONFIG_DISTRO_DEFAULTS
-+#define FDTFILE
-+#else
-+#define FDTFILE "fdtfile=undefined\0"
-+#endif
-+
- #define DEFAULT_COMMON_BOOT_TI_ARGS \
- 	"console=" CONSOLEDEV ",115200n8\0" \
--	"fdtfile=undefined\0" \
-+	FDTFILE \
- 	"bootpart=0:2\0" \
- 	"bootdir=/boot\0" \
- 	"bootfile=zImage\0" \
-@@ -200,6 +206,7 @@
+@@ -220,6 +220,7 @@
  		"if test $fdtfile = undefined; then " \
  			"echo WARNING: Could not determine device tree to use; fi; \0"
  
@@ -68,14 +53,20 @@ index 6313f3e328a0..227448c3c3cd 100644
  #define CONFIG_BOOTCOMMAND \
  	"if test ${dofastboot} -eq 1; then " \
  		"echo Boot fastboot requested, resetting dofastboot ...;" \
-@@ -215,6 +222,7 @@
+@@ -235,6 +236,13 @@
  	"run emmc_linux_boot; " \
  	"run emmc_android_boot; " \
  	""
++#else
++#undef CONFIG_BOOTCOMMAND
++/* hack, ideally we should configure the CONFIG_BOOTCOMMAND from .config */
++#define CONFIG_BOOTCOMMAND \
++	"run findfdt; " \
++	"run distro_bootcmd"
 +#endif
  
  #endif /* CONFIG_OMAP54XX */
  
 -- 
-2.25.0
+2.25.1
 

--- a/meta-ledge-bsp/recipes-kernel/linux/linux-ledge_mainline.bb
+++ b/meta-ledge-bsp/recipes-kernel/linux/linux-ledge_mainline.bb
@@ -44,4 +44,4 @@ COMPATIBLE_MACHINE = "(ledge-synquacer|ledge-stm32mp157c-dk2|ledge-qemux86-64|le
 KERNEL_SIGN_ENABLE = "1"
 
 # rename DTB
-DTB_RENAMING = "am572x-idk.dtb:omap5-am57xx.dtb "
+# DTB_RENAMING = "xyz.dtb:zyx.dtb "


### PR DESCRIPTION
commit d2fdc3800d1a ("U-Boot: TI: Enable distro_bootcmd command for am572x")
commit 462d3f3fd30d ("KERNEL: add renaming list for dts")

We enabled 'run distro_bootcmd' for am572x-idk board.
This board has it's U-boot ${soc} variable set to 'omap5' and ${board}
to 'am57xx'. Since distro_bootcmd looks for an fdt named
${soc}-${board}.dtb we also introduced a renaming scheme while building
our kernels renaming am572x-idk.dtb -> omap5-am57xx.dtb.

It turns out the same image can run on X15 beagleboard, with a
different dtb. So instead of renaming the dtb, change the U-boot command
slightly and run 'findfdt' before booting 'distro_bootcmd' and support
both boards.

Signed-off-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>