### PR TITLE
keep ext4 images needed for stm flasher

### DIFF
--- a/meta-ledge-bsp/conf/machine/ledge-qemuarm.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-qemuarm.conf
@@ -44,7 +44,7 @@ IMAGE_CLASSES += " image_types-ledgebootfs"
 IMAGE_FSTYPES += " ledgebootfs "
 
 # WIC
-IMAGE_FSTYPES_remove += "tar.bz2 tar.xz ext4"
+IMAGE_FSTYPES_remove += "tar.bz2 tar.xz"
 IMAGE_FSTYPES += "wic"
 WKS_FILE += "ledge-kernel-uefi.wks.in"
 


### PR DESCRIPTION
stm flasher uses ext4 rootfs image to create bootable
sd card.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>