### PR TITLE
FLASHLAYOUT: manage diversity

### DIFF
--- a/meta-ledge-bsp/classes/tsv_fld_ledge.bbclass
+++ b/meta-ledge-bsp/classes/tsv_fld_ledge.bbclass
@@ -9,7 +9,7 @@ tsv_fld_template_for_ledge () {
     cd ${DEPLOY_DIR_IMAGE};
 
     BOOTFS_IMAGE_NAME_DETECTED=$(readlink ${IMGDEPLOYDIR}/${BOOTFS_IMAGE_NAME})
-    ROOTFS_IMAGE_NAME_DETECTED=$(readlink ${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.wic)
+    ROOTFS_IMAGE_NAME_DETECTED=$(readlink ${IMGDEPLOYDIR}/${IMAGE_LINK_NAME}.ext4)
     ROOTFS_IMAGE_NAME_DETECTED_NAME=$(basename ${ROOTFS_IMAGE_NAME_DETECTED} )
     echo "${ROOTFS_IMAGE_NAME_DETECTED} ${ROOTFS_IMAGE_NAME_DETECTED_NAME}"
 
@@ -18,7 +18,7 @@ tsv_fld_template_for_ledge () {
     for f in $(ls -1 *.tsv.template)
     do
         name=$(echo $f | sed "s/tsv\.template/${IMAGE_LINK_NAME}\.tsv/")
-        sed "s/%%IMAGE%/${ROOTFS_IMAGE_NAME_DETECTED}.bin/" $f > $name
+        sed "s/%%IMAGE%/${ROOTFS_IMAGE_NAME_DETECTED}/" $f > $name
         sed -i "s/%%BOOTFS%/${BOOTFS_IMAGE_NAME_DETECTED}/" $name
     done
     for f in $(ls -1 *.fld.template);

--- a/meta-ledge-bsp/recipes-devtools/generate-raw-image/files/ledge-stm32mp157c-dk2/FlashLayout_sdcard_ledge-stm32mp157c-dk2-debian.tsv.template
+++ b/meta-ledge-bsp/recipes-devtools/generate-raw-image/files/ledge-stm32mp157c-dk2/FlashLayout_sdcard_ledge-stm32mp157c-dk2-debian.tsv.template
@@ -19,5 +19,5 @@ P	0x06	ssbl	Binary	mmc0	0x00084400	u-boot-trusted.stm32
 P	0x0A	teeh	Binary	mmc0	0x00284400	optee/tee-header_v2.stm32
 P	0x0B	teed	Binary	mmc0	0x002C4400	optee/tee-pageable_v2.stm32
 P	0x0C	teex	Binary	mmc0	0x00304400	optee/tee-pager_v2.stm32
-P	0x21	bootfs	System	mmc0	0x00344400	%%BOOTFS_IMAGE%
+P	0x21	bootfs	System	mmc0	0x00344400	%%BOOTFS%
 P	0x22	rootfs	FileSystem	mmc0	0x04344400	%%IMAGE%

--- a/meta-ledge-bsp/recipes-devtools/generate-raw-image/files/ledge-stm32mp157c-dk2/FlashLayout_sdcard_ledge-stm32mp157c-dk2-optee.tsv.template
+++ b/meta-ledge-bsp/recipes-devtools/generate-raw-image/files/ledge-stm32mp157c-dk2/FlashLayout_sdcard_ledge-stm32mp157c-dk2-optee.tsv.template
@@ -1,4 +1,11 @@
 #Opt	Id	Name	Type	IP	Offset	Binary
 -	0x01	fsbl1-boot	Binary	none	0x0	tf-a-stm32mp157c-dk2-flasher.stm32
 -	0x03	ssbl-boot	Binary	none	0x0	u-boot-stm32mp157c-dk2-flasher.stm32
-P	0x60	sdcardall	RawImage	mmc0	0x0	%%IMAGE%
+P	0x04	fsbl1	Binary	mmc0	0x00004400	arm-trusted-firmware/tf-a-stm32mp157c-dk2.stm32
+P	0x05	fsbl2	Binary	mmc0	0x00044400	arm-trusted-firmware/tf-a-stm32mp157c-dk2.stm32
+P	0x06	ssbl	Binary	mmc0	0x00084400	u-boot-trusted.stm32
+P	0x0A	teeh	Binary	mmc0	0x00284400	optee/tee-header_v2.stm32
+P	0x0B	teed	Binary	mmc0	0x002C4400	optee/tee-pageable_v2.stm32
+P	0x0C	teex	Binary	mmc0	0x00304400	optee/tee-pager_v2.stm32
+P	0x21	bootfs	System	mmc0	0x00344400	%%BOOTFS%
+P	0x22	rootfs	FileSystem	mmc0	0x04344400	%%IMAGE%

--- a/meta-ledge-bsp/recipes-devtools/generate-raw-image/raw-tools/create_raw_from_flashlayout.sh
+++ b/meta-ledge-bsp/recipes-devtools/generate-raw-image/raw-tools/create_raw_from_flashlayout.sh
@@ -291,7 +291,7 @@ function generate_rootfs_from_tarball() {
 	if [ -e $tsv_template_file ]
 	then
 		sed -e "s|%%IMAGE%|$_rootfs_name.ext4|g" $tsv_template_file > $tsv_file
-		sed -i -e "s|%%BOOTFS_IMAGE%|$_rootfs_name.bootfs.vfat|g" $tsv_file
+		sed -i -e "s|%%BOOTFS%|$_rootfs_name.bootfs.vfat|g" $tsv_file
 	fi
 	# clean
 	sudo rm -rf temp_rootfs


### PR DESCRIPTION
To manage the diversity of configuration, stm32mp157c-dk2, qemu, debian,
the flashlayout are simplify.
- stm32mp157-cdk2: use of ext4 image
- qemu: use of ext4 image
- debian: use of ext4 image
The wic are not more use because we are not able to know on which mode we are.

Signed-off-by: Christophe Priouzeau <christophe.priouzeau@st.com>