### PR TITLE
add only 2Gb as empty space for ext4 images.

### DIFF
--- a/meta-ledge-bsp/conf/machine/include/ledge-qemu-common.inc
+++ b/meta-ledge-bsp/conf/machine/include/ledge-qemu-common.inc
@@ -2,5 +2,5 @@ QB_TAP_OPT = "-netdev tap,id=net0,ifname=@TAP@,script=no,downscript=no"
 QB_NETWORK_DEVICE = "-device virtio-net-pci,netdev=net0,mac=@MAC@"
 QB_ROOTFS_OPT = "-drive id=disk0,file=@ROOTFS@,if=none,format=raw -device virtio-blk-device,drive=disk0"
 QB_MEM = "-m 4096"
-# add 20GB space for VM
-IMAGE_ROOTFS_EXTRA_SPACE = "20971520"
+# add 2GB space for VM
+IMAGE_ROOTFS_EXTRA_SPACE = "2097152"


### PR DESCRIPTION
We want to fit into most common sd card (8Gb or 16Gb).

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>