### PR TITLE
OPTEE-FTPM: delay startup

### DIFF
--- a/meta-ledge-sw/recipes-security/optee/optee-ftpm/optee-ftpm.service
+++ b/meta-ledge-sw/recipes-security/optee/optee-ftpm/optee-ftpm.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Load optee ftpm
+After=tee-supplicant.service
+
+[Service]
+Type=oneshot
+ExecStart=/sbin/modprobe tpm_ftpm_tee
+
+[Install]
+WantedBy=basic.target


### PR DESCRIPTION
Do not load optee-ftpm driver if tee-supplicant are not started.
Load optee-ftpm driver on systemd service after tee-supplicant service.

Signed-off-by: Christophe Priouzeau <christophe.priouzeau@st.com>