### PR TITLE
make crtl+c work with runqemu script

### DIFF
--- a/meta-ledge-bsp/conf/machine/ledge-qemuarm.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-qemuarm.conf
@@ -55,7 +55,7 @@ QB_CPU = "-cpu cortex-a15"
 QB_MEM = "-m 1024"
 QB_KERNEL_CMDLINE_APPEND = "console=ttyAMA0,115200 console=tty"
 # Add the 'virtio-rng-pci' device otherwise the guest may run out of entropy
-QB_OPT_APPEND = "-show-cursor -device virtio-rng-pci -monitor null -nographic -d unimp -semihosting-config enable,target=native -bios bl1.bin -dtb ledge-qemuarm.dtb -drive id=disk1,file=ledge-kernel-uefi-certs.ext4.img,if=none,format=raw -device virtio-blk-device,drive=disk1"
+QB_OPT_APPEND = "-show-cursor -device virtio-rng-pci -serial stdio -monitor null -nographic -d unimp -semihosting-config enable,target=native -bios bl1.bin -dtb ledge-qemuarm.dtb -drive id=disk1,file=ledge-kernel-uefi-certs.ext4.img,if=none,format=raw -device virtio-blk-device,drive=disk1"
 QB_SERIAL_OPT = "-device virtio-serial-device -chardev null,id=virtcon -device virtconsole,chardev=virtcon"
 QB_DRIVE_TYPE = "/dev/vdb"
 QB_ROOTFS_OPT = "-drive id=disk0,file=@ROOTFS@,if=none,format=raw -device virtio-blk-device,drive=disk0"

--- a/meta-ledge-bsp/conf/machine/ledge-qemuarm64.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-qemuarm64.conf
@@ -55,7 +55,7 @@ QB_MACHINE = "-machine virt,secure=on"
 QB_CPU = "-cpu cortex-a57"
 QB_KERNEL_CMDLINE_APPEND = "console=ttyAMA0,115200 console=tty"
 # Add the 'virtio-rng-pci' device otherwise the guest may run out of entropy
-QB_OPT_APPEND = "-show-cursor -device virtio-rng-pci -monitor null -nographic -d unimp -semihosting-config enable,target=native -bios bl1.bin -dtb ledge-qemuarm64.dtb -drive id=disk1,file=ledge-kernel-uefi-certs.ext4.img,if=none,format=raw -device virtio-blk-device,drive=disk1"
+QB_OPT_APPEND = "-show-cursor -device virtio-rng-pci -serial stdio -monitor null -nographic -d unimp -semihosting-config enable,target=native -bios bl1.bin -dtb ledge-qemuarm64.dtb -drive id=disk1,file=ledge-kernel-uefi-certs.ext4.img,if=none,format=raw -device virtio-blk-device,drive=disk1"
 QB_SERIAL_OPT = "-device virtio-serial-device -chardev null,id=virtcon -device virtconsole,chardev=virtcon"
 QB_DRIVE_TYPE = "/dev/vdb"
 QB_ROOTFS_OPT = "-drive id=disk0,file=@ROOTFS@,if=none,format=raw -device virtio-blk-device,drive=disk0"


### PR DESCRIPTION
add -serial stdio to allow ctrl+c interrupt runqemu
script.
I.e.
runqemu ledg.qemuboot.conf wic - will trap on crtl+c
runqemu ledg.qemuboot.conf wic serial - will not trap on ctrl+c
and passes signal to virtual machine.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>