### PR TITLE
Raw script: add support of partition type

### DIFF
--- a/meta-ledge-bsp/recipes-devtools/generate-raw-image/files/aarch64/FlashLayout_sdcard_arm64_without_boot_firmware.fld
+++ b/meta-ledge-bsp/recipes-devtools/generate-raw-image/files/aarch64/FlashLayout_sdcard_arm64_without_boot_firmware.fld
@@ -7,7 +7,7 @@
 # =   (1 )     =    (2 )    =
 # =            =            =
 # =========================================================================================================
-#Opt: P=Populate, E=Empty
+#Opt: P=Populate, E=Empty, R=Raw
 #Type: Binary=raw partition, FileSystem=fs partition(ext4, fat)
 #Ofsset on hexa
 #Opt	Name	Type	Offset	Binary
@@ -15,5 +15,6 @@ URI		https://snapshots.linaro.org/components/ledge/oe/ledge-qemuarm64/latest/rpb
 MODULE	modules-stripped-ledge-qemuarm64-for-debian.tgz
 UUID	6091b3a4-ce08-3020-93a6-f755a22ef03b
 ARCH	arm64
+PARTITION	GPT
 P	bootfs	System	0x00344400	ledge-iot-ledge-qemuarm64.bootfs.vfat.gz
 P	rootfs	FileSystem	0x04344400	rootfs-linaro-buster-raw-unknown-*.tar.xz

--- a/meta-ledge-bsp/recipes-devtools/generate-raw-image/files/armv7a/FlashLayout_sdcard_armhf_without_boot_firmware.fld
+++ b/meta-ledge-bsp/recipes-devtools/generate-raw-image/files/armv7a/FlashLayout_sdcard_armhf_without_boot_firmware.fld
@@ -7,7 +7,7 @@
 # =   (1 )     =    (2 )    =
 # =            =            =
 # =========================================================================================================
-#Opt: P=Populate, E=Empty
+#Opt: P=Populate, E=Empty, R=Raw
 #Type: Binary=raw partition, FileSystem=fs partition(ext4, fat)
 #Ofsset on hexa
 #Opt	Name	Type	Offset	Binary
@@ -15,5 +15,6 @@ URI		https://snapshots.linaro.org/components/ledge/oe/ledge-multi-armv7/latest/r
 MODULE	modules-stripped-ledge-qemuarm-for-debian.tgz
 UUID	6091b3a4-ce08-3020-93a6-f755a22ef03b
 ARCH	armhf
+PARTITION	GPT
 P	bootfs	System	0x00344400	ledge-iot-ledge-qemuarm.bootfs.vfat.gz
 P	rootfs	FileSystem	0x04344400	rootfs-linaro-buster-raw-unknown-*.tar.xz

--- a/meta-ledge-bsp/recipes-devtools/generate-raw-image/files/ledge-qemuarm/FlashLayout_sdcard_ledge-stm32mp157c-dk2-optee.tsv.template
+++ b/meta-ledge-bsp/recipes-devtools/generate-raw-image/files/ledge-qemuarm/FlashLayout_sdcard_ledge-stm32mp157c-dk2-optee.tsv.template
@@ -1,3 +1,5 @@
+PARTITION	GPT
+UUID	6091b3a4-ce08-3020-93a6-f755a22ef03b
 #Opt	Id	Name	Type	IP	Offset	Binary
 -	0x01	fsbl1-boot	Binary	none	0x0	tf-a-stm32mp157c-dk2-flasher.stm32
 -	0x03	ssbl-boot	Binary	none	0x0	u-boot-stm32mp157c-dk2-flasher.stm32

--- a/meta-ledge-bsp/recipes-devtools/generate-raw-image/files/ledge-stm32mp157c-dk2/FlashLayout_sdcard_ledge-stm32mp157c-dk2-debian.fld
+++ b/meta-ledge-bsp/recipes-devtools/generate-raw-image/files/ledge-stm32mp157c-dk2/FlashLayout_sdcard_ledge-stm32mp157c-dk2-debian.fld
@@ -7,7 +7,7 @@
 # =    (1 )    =    (2 )    =    (3 )    =    (4 )    =    (5 )    =    (6 )    =    (7 )    =    (8 )    =
 # =            =            =            =            =            =            =            =            =
 # =========================================================================================================
-#Opt: P=Populate, E=Empty
+#Opt: P=Populate, E=Empty, R=Raw
 #Type: Binary=raw partition, FileSystem=fs partition(ext4, fat)
 #Ofsset on hexa
 #Opt	Name	Type	Offset	Binary
@@ -15,6 +15,7 @@ URI		https://snapshots.linaro.org/components/ledge/oe/ledge-stm32mp157c-dk2/late
 MODULE	modules-stripped-ledge-stm32mp157c-dk2-for-debian.tgz
 UUID	6091b3a4-ce08-3020-93a6-f755a22ef03b
 ARCH	armhf
+PARTITION	GPT
 P	fsbl1	Binary	0x00004400	arm-trusted-firmware/tf-a-stm32mp157c-dk2.stm32
 P	fsbl2	Binary	0x00044400	arm-trusted-firmware/tf-a-stm32mp157c-dk2.stm32
 P	ssbl	Binary	0x00084400	u-boot-trusted.stm32

--- a/meta-ledge-bsp/recipes-devtools/generate-raw-image/files/ledge-stm32mp157c-dk2/FlashLayout_sdcard_ledge-stm32mp157c-dk2-optee.fld.template
+++ b/meta-ledge-bsp/recipes-devtools/generate-raw-image/files/ledge-stm32mp157c-dk2/FlashLayout_sdcard_ledge-stm32mp157c-dk2-optee.fld.template
@@ -7,7 +7,9 @@
 # =    (1 )    =    (2 )    =    (3 )    =    (4 )    =    (5 )    =    (6 )    =    (7 )    =    (8 )    =
 # =            =            =            =            =            =            =            =            =
 # =========================================================================================================
-#Opt: P=Populate, E=Empty
+PARTITION	GPT
+UUID	6091b3a4-ce08-3020-93a6-f755a22ef03b
+#Opt: P=Populate, E=Empty, R=Raw
 #Type: Binary=raw partition, FileSystem=fs partition(ext4, fat)
 #Ofsset on hexa
 #Opt	Name	Type	Offset	Binary


### PR DESCRIPTION
Support of Partition type: gpt and dos. 
Add support of raw content (not associated to a partition.

Example with dos partition type:
PARTITION	DOS
#Opt: P=Populate, E=Empty R=Raw
#Type: Binary=raw partition, FileSystem=fs partition(ext4, fat)
#Ofsset on hexa
#Opt	Name	Type	Offset	Binary
R	fsbl1	Binary	0x00004400	arm-trusted-firmware/tf-a-stm32mp157c-dk2.stm32
R	fsbl2	Binary	0x00044400	arm-trusted-firmware/tf-a-stm32mp157c-dk2.stm32
P	bootfs	System	0x00344400	ledge-iot-ledge-stm32mp157c-dk2-20200310014126.bootfs.vfat
P	rootfs	FileSystem	0x04344400	ledge-iot-ledge-stm32mp157c-dk2-20200310014126.rootfs.ext4