### PR TITLE
sysctl: lower kernel verbosity on boot

### DIFF
--- a/meta-ledge-sw/recipes-extended/procps/procps_%.bbappend
+++ b/meta-ledge-sw/recipes-extended/procps/procps_%.bbappend
@@ -1,0 +1,5 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}/:"
+
+do_install_append() {
+        echo kernel.printk = 1 1 1 1 >> ${D}${sysconfdir}/sysctl.conf
+}


### PR DESCRIPTION
disable audit messages on boot console.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>