### PR TITLE
qemuarm64: do not delete tar.xz image

### DIFF
--- a/meta-ledge-bsp/conf/machine/ledge-qemuarm64.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-qemuarm64.conf
@@ -45,7 +45,7 @@ IMAGE_CLASSES += " image_types-ledgebootfs"
 IMAGE_FSTYPES += " ledgebootfs "
 
 # WIC
-IMAGE_FSTYPES_remove += "tar.bz2 tar.xz ext4"
+IMAGE_FSTYPES_remove += "tar.bz2 ext4"
 IMAGE_FSTYPES += "wic"
 WKS_FILE += "ledge-kernel-uefi.wks.in"
 WIC_CREATE_EXTRA_ARGS += "--no-fstab-update"


### PR DESCRIPTION
ledge-synquacer uses tag.xz which is used on multi-platfrom
builds.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>
--
this has to fix synquacer lava job for multi platform builds.