### PR TITLE
ledge-qemu-x86: revert back mount rootfs from initrd

### DIFF
--- a/meta-ledge-bsp/recipes-kernel/linux/linux-ledge/fragment-13-cmdline_x86.config
+++ b/meta-ledge-bsp/recipes-kernel/linux/linux-ledge/fragment-13-cmdline_x86.config
@@ -4,4 +4,4 @@ CONFIG_ARM_ATAG_DTB_COMPAT=y
 CONFIG_ARM_ATAG_DTB_COMPAT_CMDLINE_EXTEND=y
 CONFIG_CMDLINE_BOOL=y
 CONFIG_CMDLINE_EXTEND=y
-CONFIG_CMDLINE="rootdelay=20 initrd=/ledge-initramfs.rootfs.cpio.gz root=UUID=6091b3a4-ce08-3020-93a6-f755a22ef03b console=ttyS0,115200"
+CONFIG_CMDLINE="rootdelay=20 initrd=/ledge-initramfs.rootfs.cpio.gz root=PARTLABEL=rootfs console=ttyS0,115200"


### PR DESCRIPTION
linux kernel before 5.7 does not support initrd passed
from UEFI. Use this patch as temporary solution to mount
rootfs by label.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>