### PR TITLE
revert: 872ea3e CONF: Use enforcing policy for selinux

### DIFF
--- a/meta-ledge-sw/conf/layer.conf
+++ b/meta-ledge-sw/conf/layer.conf
@@ -19,7 +19,7 @@ PACKAGECONFIG_pn-sudo = "pam-wheel"
 
 # set permissive mode for now. We can change this to enforcing once we have the
 # proper policy installed
-DEFAULT_ENFORCING = "enforcing"
+DEFAULT_ENFORCING = "permissive"
 
 # enable EFI
 DISTRO_FEATURES_append = " efi"


### PR DESCRIPTION
partially revert:
872ea3e CONF: Use enforcing policy for selinux
For now selinux blocks reboot and shutdown for root user.
This commit reverts default selinux policy which to permissive
- i.e. generate warnings instead of block commands. For not it's
intended that admin have to update selinux rules for his
applications then switch selinux mode to enforcing (blocking mode).

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>