### PR TITLE
ledge-iot: add systemd-analyze utility

### DIFF
--- a/meta-ledge-sw/recipes-samples/packagegroups/packagegroup-ledge-iot.bb
+++ b/meta-ledge-sw/recipes-samples/packagegroups/packagegroup-ledge-iot.bb
@@ -165,6 +165,7 @@ RDEPENDS_packagegroup-ledge-iot = "\
 	sqlite3 \
 	sudo \
 	systemd \
+	systemd-analyze \
 	tar \
 	tmux \
 	traceroute \


### PR DESCRIPTION
systemd-analyze can be used to to get statistics
for system boot. Like:
~#systemd-analyze time
Startup finished in 11.999s (kernel) + 43.946s (userspace) = 55.946s
multi-user.target reached after 41.802s in userspace

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>