### PR TITLE
runqemu: fimware->firmware and do not pass dtb

### DIFF
--- a/meta-ledge-bsp/conf/machine/ledge-qemuarm.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-qemuarm.conf
@@ -56,7 +56,7 @@ QB_CPU = "-cpu cortex-a15"
 QB_MEM = "-m 1024"
 QB_KERNEL_CMDLINE_APPEND = "console=ttyAMA0,115200 console=tty"
 # Add the 'virtio-rng-pci' device otherwise the guest may run out of entropy
-QB_OPT_APPEND = "-show-cursor -device virtio-rng-pci -serial stdio -monitor null -nographic -d unimp -bios firmware.bin -dtb ledge-qemuarm.dtb -drive id=disk1,file=ledge-kernel-uefi-certs.ext4.img,if=none,format=raw -device virtio-blk-device,drive=disk1"
+QB_OPT_APPEND = "-show-cursor -device virtio-rng-pci -serial stdio -monitor null -nographic -d unimp -bios firmware.bin -drive id=disk1,file=ledge-kernel-uefi-certs.ext4.img,if=none,format=raw -device virtio-blk-device,drive=disk1"
 QB_SERIAL_OPT = "-device virtio-serial-device -chardev null,id=virtcon -device virtconsole,chardev=virtcon"
 QB_DRIVE_TYPE = "/dev/vdb"
 QB_ROOTFS_OPT = "-drive id=disk0,file=@ROOTFS@,if=none,format=raw -device virtio-blk-device,drive=disk0"

--- a/meta-ledge-bsp/conf/machine/ledge-qemuarm64.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-qemuarm64.conf
@@ -55,7 +55,7 @@ QB_MACHINE = "-machine virt,secure=on"
 QB_CPU = "-cpu cortex-a57"
 QB_KERNEL_CMDLINE_APPEND = "console=ttyAMA0,115200 console=tty"
 # Add the 'virtio-rng-pci' device otherwise the guest may run out of entropy
-QB_OPT_APPEND = "-show-cursor -device virtio-rng-pci -serial stdio -monitor null -nographic -d unimp -bios fimware.bin -dtb ledge-qemuarm64.dtb -drive id=disk1,file=ledge-kernel-uefi-certs.ext4.img,if=none,format=raw -device virtio-blk-device,drive=disk1"
+QB_OPT_APPEND = "-show-cursor -device virtio-rng-pci -serial stdio -monitor null -nographic -d unimp -bios firmware.bin -drive id=disk1,file=ledge-kernel-uefi-certs.ext4.img,if=none,format=raw -device virtio-blk-device,drive=disk1"
 QB_SERIAL_OPT = "-device virtio-serial-device -chardev null,id=virtcon -device virtconsole,chardev=virtcon"
 QB_DRIVE_TYPE = "/dev/vdb"
 QB_ROOTFS_OPT = "-drive id=disk0,file=@ROOTFS@,if=none,format=raw -device virtio-blk-device,drive=disk0"


### PR DESCRIPTION
we fix dtb in qemu binary, no need to pass it as command
line.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>