### PR TITLE
remove unbuildable packages for dunfell branch

### DIFF
--- a/meta-ledge-sw/recipes-samples/packagegroups/packagegroup-ledge-iot.bb
+++ b/meta-ledge-sw/recipes-samples/packagegroups/packagegroup-ledge-iot.bb
@@ -17,7 +17,6 @@ RDEPENDS_packagegroup-ledge-iot = "\
 	ca-certificates \
 	cloud-init \
 	checkpolicy \
-	chkconfig \
 	chrony \
 	coreutils \
 	cpio \
@@ -25,7 +24,6 @@ RDEPENDS_packagegroup-ledge-iot = "\
 	${@bb.utils.contains_any("TUNE_ARCH", [ "x86_64", "arm" ] , "criu", "", d)} \
 	curl \
 	diffutils \
-	dnf \
 	dnsmasq \
 	dracut \
 	e2fsprogs \
@@ -151,7 +149,6 @@ RDEPENDS_packagegroup-ledge-iot = "\
 	python3-systemd \
 	python3-urllib3 \
 	python3-websocket-client \
-	python-setuptools \
 	qrencode \
 	readline \
 	rng-tools \


### PR DESCRIPTION
chkconfig, python-setuptools - is not needed on target.
dnf - is package manager,  opkg is used for OE.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>