### PR TITLE
remove python-pyyaml from lava images

### DIFF
--- a/meta-ledge-sw/recipes-samples/packagegroups/packagegroup-ledge-tpm-lava.bb
+++ b/meta-ledge-sw/recipes-samples/packagegroups/packagegroup-ledge-tpm-lava.bb
@@ -4,7 +4,7 @@ inherit packagegroup
 
 RDEPENDS_packagegroup-ledge-tpm-lava = "\
     git \
-    python-pyyaml \
+    python3-pyyaml \
     vim \
     perl \
     openssl-bin \


### PR DESCRIPTION
remove unbildable package python-pyyaml from
dunfell branch.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>