### PR TITLE
CONF:TI: use UBOOT_CONFIG instead of UBOOT_MACHINE

### DIFF
--- a/meta-ledge-bsp/conf/machine/ledge-ti-am572x.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-ti-am572x.conf
@@ -29,7 +29,10 @@ PACKAGECONFIG_pn_mesa = "${@bb.utils.filter('DISTRO_FEATURES', 'wayland ', d)} \
 KERNEL_DEVICETREE = "am572x-idk.dtb"
 
 PREFERRED_PROVIDER_virtual/bootloader = "u-boot-ledge"
-UBOOT_MACHINE = "am57xx_evm_defconfig"
+PREFERRED_PROVIDER_u-boot = "u-boot-ledge"
+unset UBOOT_MACHINE
+UBOOT_CONFIG = "trusted"
+UBOOT_CONFIG[trusted] = "am57xx_evm_defconfig,,u-boot.img"
 
 MACHINE_EXTRA_RRECOMMENDS = "prueth-fw optee-os"
 MACHINE_FEATURES += "optee"


### PR DESCRIPTION
 
Signed-off-by: Christophe Priouzeau <christophe.priouzeau@st.com>