### PR TITLE
uboot: add virtual/bootloader

### DIFF
--- a/meta-ledge-bsp/recipes-bsp/u-boot/u-boot-ledge.bb
+++ b/meta-ledge-bsp/recipes-bsp/u-boot/u-boot-ledge.bb
@@ -30,8 +30,8 @@ SRC_URI_append_ledge-qemuarm64 = " file://ledge-qemuarm64_defconfig"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 require recipes-bsp/u-boot/u-boot.inc
-PROVIDES += "u-boot"
-RPROVIDES_${PN} += "u-boot"
+PROVIDES += "u-boot virtual/bootloader"
+RPROVIDES_${PN} += "u-boot virtual/bootloader"
 
 DEPENDS += "bc-native dtc-native"
 


### PR DESCRIPTION
stm target depens on virtual/bootloader on RDEPENDS,
but uboot.inc adds it only to DEPENDS. Define virtual
provider for RDEPENDS as well.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>