### PR TITLE
rename firmware images to common name

### DIFF
--- a/meta-ledge-bsp/recipes-bsp/edk2-efi-prebuild-fw/edk2-efi-prebuild-fw.bb
+++ b/meta-ledge-bsp/recipes-bsp/edk2-efi-prebuild-fw/edk2-efi-prebuild-fw.bb
@@ -62,7 +62,7 @@ do_deploy() {
 do_deploy_append_ledge-qemuarm64() {
 	install -m 0644 ${B}/RELEASEAARCH64_Shell.efi ${D}/boot/EFI/BOOT/${EFI_SHELL}
 	install -m 0644 ${B}/RELEASEAARCH64_Shell.efi ${DEPLOYDIR}/edk2_shell.efi
-	install -m 0644 ${B}/RELEASEAARCH64_QEMU_EFI.fd ${DEPLOYDIR}/firmware-edk2.fd
+	install -m 0644 ${B}/RELEASEAARCH64_QEMU_EFI.fd ${DEPLOYDIR}/firmware.uefi-edk2.bin
 }
 
 do_deploy_append_synquacer() {
@@ -73,7 +73,7 @@ do_deploy_append_synquacer() {
 do_deploy_append_ledge-qemuarm() {
         install -m 0644 ${B}/RELEASEARM_Shell.efi ${D}/boot/EFI/BOOT/${EFI_SHELL}
 	install -m 0644 ${B}/RELEASEARM_Shell.efi ${DEPLOYDIR}/edk2_shell.efi
-	install -m 0644 ${B}/RELEASEARM_QEMU_EFI.fd ${DEPLOYDIR}/firmware-edk2.fd
+	install -m 0644 ${B}/RELEASEARM_QEMU_EFI.fd ${DEPLOYDIR}/firmware.uefi-edk2.bin
 }
 
 do_deploy_append_ledge-stm32mp157c-dk2() {
@@ -89,7 +89,7 @@ do_deploy_append_ledge-ti-am572x() {
 do_deploy_append_ledge-x86_64() {
         install -m 0644 ${B}/RELEASEX64_Shell.efi ${D}/boot/EFI/BOOT/${EFI_SHELL}
 	install -m 0644 ${B}/RELEASEX64_Shell.efi ${DEPLOYDIR}/edk2_shell.efi
-	install -m 0644 ${B}/RELEASEX64_OVMF.fd ${DEPLOYDIR}/firmware-edk2.fd
+	install -m 0644 ${B}/RELEASEX64_OVMF.fd ${DEPLOYDIR}/firmware.uefi-edk2.bin
 }
 
 addtask deploy after do_install

--- a/meta-ledge-bsp/recipes-bsp/trusted-firmware-a/trusted-firmware-a-ledge_git.bb
+++ b/meta-ledge-bsp/recipes-bsp/trusted-firmware-a/trusted-firmware-a-ledge_git.bb
@@ -131,8 +131,9 @@ do_deploy() {
 
     if [ -f ${B}/fip.bin ] ; then
         install -m 0644 ${B}/fip.bin ${DEPLOYDIR}/
-	dd if=${B}/bl1.bin of=${DEPLOYDIR}/firmware.bin bs=4096 conv=notrunc
-	dd if=${B}/fip.bin of=${DEPLOYDIR}/firmware.bin seek=64 bs=4096 conv=notrunc
+	dd if=${B}/bl1.bin of=${DEPLOYDIR}/firmware.uefi.uboot.bin bs=4096 conv=notrunc
+	dd if=${B}/fip.bin of=${DEPLOYDIR}/firmware.uefi.uboot.bin seek=64 bs=4096 conv=notrunc
+	ln -sf firmware.uefi.uboot.bin ${DEPLOYDIR}/firmware.bin
     fi
 }
 


### PR DESCRIPTION
Use firmare images name as we agreed to be used by run
and CI scripts.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>