### PR TITLE
ledge-qemux86-64: add edk2 fw to RRDPENDS and remove ovmf build

### DIFF
--- a/meta-ledge-bsp/conf/machine/ledge-qemux86-64.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-qemux86-64.conf
@@ -40,10 +40,10 @@ MACHINE_FEATURES += "x86 pci"
 MACHINE_FEATURES += "pcbios efi"
 
 MACHINE_ESSENTIAL_EXTRA_RDEPENDS += "v86d"
-EXTRA_IMAGEDEPENDS += " ovmf edk2-efi-prebuild-fw "
 
-MACHINE_EXTRA_RRECOMMENDS = "kernel-module-snd-ens1370 kernel-module-snd-rawmidi"
-
+MACHINE_EXTRA_RDEPENDS += " \
+    edk2-efi-prebuild-fw \
+    "
 KERNEL_MODULE_AUTOLOAD += "uvesafb"
 KERNEL_MODULE_PROBECONF += "uvesafb"
 module_conf_uvesafb = "options uvesafb mode_option=${UVESA_MODE}"


### PR DESCRIPTION
Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>