### PR TITLE
ledge-qemuarm64: use firmware.uefi.bin for pflash

### DIFF
--- a/meta-ledge-bsp/conf/machine/ledge-qemuarm64.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-qemuarm64.conf
@@ -60,7 +60,7 @@ QB_CPU = "-cpu cortex-a57"
 QB_MEM = "-m 2048"
 QB_KERNEL_CMDLINE_APPEND = "console=ttyAMA0,115200 console=tty"
 # Add the 'virtio-rng-pci' device otherwise the guest may run out of entropy
-QB_OPT_APPEND = "-device virtio-rng-pci -serial stdio -monitor null -nographic -d unimp -drive id=disk1,file=ledge-kernel-uefi-certs.ext4.img,if=none,format=raw -device virtio-blk-device,drive=disk1 -device i6300esb,id=watchdog0 -drive if=pflash,unit=0,readonly=off,file=sec_nor_flash.bin"
+QB_OPT_APPEND = "-device virtio-rng-pci -serial stdio -monitor null -nographic -d unimp -drive id=disk1,file=ledge-kernel-uefi-certs.ext4.img,if=none,format=raw -device virtio-blk-device,drive=disk1 -device i6300esb,id=watchdog0 -drive if=pflash,unit=0,readonly=off,file=firmware.bin,format=raw"
 QB_SERIAL_OPT = "-device virtio-serial-device -chardev null,id=virtcon -device virtconsole,chardev=virtcon"
 QB_DRIVE_TYPE = "/dev/vdb"
 QB_ROOTFS_OPT = "-drive id=disk0,file=@ROOTFS@,if=none,format=raw -device virtio-blk-device,drive=disk0"

--- a/meta-ledge-bsp/recipes-bsp/trusted-firmware-a/trusted-firmware-a-ledge_git.bb
+++ b/meta-ledge-bsp/recipes-bsp/trusted-firmware-a/trusted-firmware-a-ledge_git.bb
@@ -133,9 +133,10 @@ do_deploy() {
 
     if [ -f ${B}/fip.bin ] ; then
         install -m 0644 ${B}/fip.bin ${DEPLOYDIR}/
-	dd if=${B}/bl1.bin of=${DEPLOYDIR}/firmware.uefi.uboot.bin bs=4096 conv=notrunc
-	dd if=${B}/fip.bin of=${DEPLOYDIR}/firmware.uefi.uboot.bin seek=64 bs=4096 conv=notrunc
-	ln -sf firmware.uefi.uboot.bin ${DEPLOYDIR}/firmware.bin
+        dd if=/dev/zero of=${DEPLOYDIR}/firmware.uefi.uboot.bin count=131072
+        dd if=${B}/bl1.bin of=${DEPLOYDIR}/firmware.uefi.uboot.bin bs=4096 conv=notrunc
+        dd if=${B}/fip.bin of=${DEPLOYDIR}/firmware.uefi.uboot.bin seek=64 bs=4096 conv=notrunc
+        ln -sf firmware.uefi.uboot.bin ${DEPLOYDIR}/firmware.bin
     fi
 }
 
@@ -151,11 +152,6 @@ do_deploy_append_ledge-qemuarm64() {
     ln -sf arm-trusted-firmware/bl1.bin  bl1.bin
     ln -sf arm-trusted-firmware/bl2.bin  bl2.bin
     ln -sf arm-trusted-firmware/bl31.bin bl31.bin
-    if [ ! -f sec_nor_flash.bin ] ; then
-        dd if=/dev/zero of=sec_nor_flash.bin count=131072
-    fi
-    dd if=bl1.bin of=sec_nor_flash.bin bs=4096 conv=notrunc
-    dd if=fip.bin of=sec_nor_flash.bin seek=64 bs=4096 conv=notrunc
     cd -
 }
 


### PR DESCRIPTION
use firmware.uefi.bin for pflash device.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>