### PR TITLE
packages: reenable ftpm

### DIFF
--- a/meta-ledge-sw/recipes-samples/packagegroups/packagegroup-ledge-optee.bb
+++ b/meta-ledge-sw/recipes-samples/packagegroups/packagegroup-ledge-optee.bb
@@ -6,5 +6,5 @@ RDEPENDS_packagegroup-ledge-optee = "\
     optee-client\
     optee-test \
     optee-ledge \
-    ${@bb.utils.contains("MACHINE_FEATURES", "ftpm", "", "", d)} \
+    ${@bb.utils.contains("MACHINE_FEATURES", "ftpm", "optee-ftpm", "", d)} \
     "


### PR DESCRIPTION
commit b90bdec4ff95("U-BOOT: add patch for stm32mp157c-dk2")
accidentally removed fTPM compilation. Fix it

Signed-off-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>