### PR TITLE
ftpm: Fix compilation and bump to latest

### DIFF
--- a/meta-ledge-sw/recipes-security/optee/optee-ftpm/0000-fix-ssl-fallthrough.patch
+++ b/meta-ledge-sw/recipes-security/optee/optee-ftpm/0000-fix-ssl-fallthrough.patch
@@ -1,0 +1,13 @@
+diff --git a/wolfssl/wolfcrypt/types.h b/wolfssl/wolfcrypt/types.h
+index 7b3a953aebda..e156ae5c7909 100755
+--- a/external/wolfssl/wolfssl/wolfcrypt/types.h
++++ b/external/wolfssl/wolfssl/wolfcrypt/types.h
+@@ -181,7 +181,7 @@
+     /* GCC 7 has new switch() fall-through detection */
+     #if defined(__GNUC__)
+         #if ((__GNUC__ > 7) || ((__GNUC__ == 7) && (__GNUC_MINOR__ >= 1)))
+-            #define FALL_THROUGH __attribute__ ((fallthrough));
++            #define FALL_THROUGH __attribute__ ((__fallthrough__));
+         #endif
+     #endif
+     #ifndef FALL_THROUGH


### PR DESCRIPTION
Fix the attribute(fallthrough) issue caused by optee and wolfssl macros.
While at it update to the latest master branch

Signed-off-by: Ilias Apalodimas <ilias.apalodimas@linaro.org>