### PR TITLE
podman: add core-utils for get hosts chcon

### DIFF
--- a/meta-ledge-sw/recipes-containers/podman/podman_git.bbappend
+++ b/meta-ledge-sw/recipes-containers/podman/podman_git.bbappend
@@ -1,0 +1,2 @@
+# for 'chcon' tool
+DEPENDS += "coreutils-native"


### PR DESCRIPTION
Podman failed on execution hosts chcon on install stage:
chcon --verbose --reference=$(DESTDIR)$(BINDIR)/podman bin/podman

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>