### PR TITLE
use common name for firmware (edk2 and uboot)

### DIFF
--- a/meta-ledge-bsp/recipes-bsp/edk2-efi-prebuild-fw/edk2-efi-prebuild-fw.bb
+++ b/meta-ledge-bsp/recipes-bsp/edk2-efi-prebuild-fw/edk2-efi-prebuild-fw.bb
@@ -30,18 +30,18 @@ do_deploy() {
 
 do_deploy_append_ledge-qemuarm64() {
     dd if=/dev/zero bs=1M count=64 of=${DEPLOYDIR}/firmware.uefi-edk2.bin
-    dd if=${B}/RELEASEAARCH64_QEMU_EFI.fd  bs=1M of=${DEPLOYDIR}/firmware.uefi-edk2.bin conv=notrunc
+    dd if=${B}/RELEASEAARCH64_QEMU_EFI.fd  bs=1M of=${DEPLOYDIR}/firmware.uefi.edk2.bin conv=notrunc
     install -m 0644  ${B}/LEDGE_AARCH64_QEMU_VARS.fd ${DEPLOYDIR}/LEDGE_AARCH64_QEMU_VARS.bin
 }
 
 do_deploy_append_ledge-qemuarm() {
     dd if=/dev/zero bs=1M count=64 of=${DEPLOYDIR}/firmware.uefi-edk2.bin
-    dd if=${B}/RELEASEARM_QEMU_EFI.fd bs=1M of=${DEPLOYDIR}/firmware.uefi-edk2.bin conv=notrunc
+    dd if=${B}/RELEASEARM_QEMU_EFI.fd bs=1M of=${DEPLOYDIR}/firmware.uefi.edk2.bin conv=notrunc
     install -m 0644 ${B}/LEDGE_ARM_QEMU_VARS.fd ${DEPLOYDIR}/LEDGE_ARM_QEMU_VARS.bin
 }
 
 do_deploy_append_ledge-qemux86-64() {
-    install -m 0644 ${B}/LEDGE_RELEASEX64_OVMF.fd ${DEPLOYDIR}/firmware.uefi-edk2.bin
+    install -m 0644 ${B}/LEDGE_RELEASEX64_OVMF.fd ${DEPLOYDIR}/firmware.uefi.edk2.bin
 }
 
 addtask deploy after do_install


### PR DESCRIPTION
firmware.uefi.edk2.bin
firmware.uefi.uboot.bin

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>