### PR TITLE
linux-ledge: add elfutils-native deps

### DIFF
--- a/meta-ledge-bsp/recipes-kernel/linux/linux-ledge_mainline.bb
+++ b/meta-ledge-bsp/recipes-kernel/linux/linux-ledge_mainline.bb
@@ -2,7 +2,7 @@ DESCRIPTION = "Linux Kernel"
 HOMEPAGE = "www.kernel.org"
 LICENSE = "GPLv2"
 SECTION = "kernel"
-DEPENDS = ""
+DEPENDS = "${@bb.utils.contains('ARCH', 'x86', 'elfutils-native', '', d)}"
 
 include linux-ledge-common.inc
 include linux-ledge-sign.inc


### PR DESCRIPTION
Fix build under docker without insalled elfutils:
|   HOSTCC  scripts/bin2c
| error: Cannot generate ORC metadata for CONFIG_UNWINDER_ORC=y,
	please install libelf-dev, libelf-devel or elfutils-libelf-devel
|   HOSTCC  scripts/kallsyms

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>

p.s.
the same dep has yocto-linux.bb
