### PR TITLE
do not redefine packagegroup-security-tpm2

### DIFF
--- a/meta-ledge-bsp/conf/machine/ledge-ti-am572x.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-ti-am572x.conf
@@ -32,7 +32,7 @@ PREFERRED_PROVIDER_virtual/bootloader = "u-boot-ledge"
 PREFERRED_PROVIDER_u-boot = "u-boot-ledge"
 unset UBOOT_MACHINE
 UBOOT_CONFIG = "trusted"
-UBOOT_CONFIG[trusted] = "am57xx_evm_defconfig,,u-boot.img"
+UBOOT_CONFIG[trusted] = "ledge-ti-am572x_defconfig,,u-boot.img"
 EXTRA_IMAGEDEPENDS_remove = "u-boot"
 
 MACHINE_EXTRA_RRECOMMENDS = "prueth-fw optee-os"

--- a/meta-ledge-sw/recipes-samples/packagegroups/packagegroup-security-tpm2.bbappend
+++ b/meta-ledge-sw/recipes-samples/packagegroups/packagegroup-security-tpm2.bbappend
@@ -6,7 +6,7 @@ RDEPENDS_packagegroup-security-tpm2_remove = " \
     cryptsetup-tpm-incubator \
     "
 
-RDEPENDS_packagegroup-security-tpm2 = " \
+RDEPENDS_packagegroup-security-tpm2_append = " \
     parsec \
     parsec-tool \
     "


### PR DESCRIPTION
append is definately missing to extend security
package with parsec instead of redifine the list.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>