### PR TITLE
ledge-ti-am572x.conf: set wks file

### DIFF
--- a/meta-ledge-bsp/conf/machine/ledge-ti-am572x.conf
+++ b/meta-ledge-bsp/conf/machine/ledge-ti-am572x.conf
@@ -55,8 +55,8 @@ IMAGE_FSTYPES += " ledgebootfs "
 # WIC
 IMAGE_BOOT_FILES ?= "u-boot.img MLO"
 IMAGE_FSTYPES_remove += "tar.bz2 tar.xz ext4"
-IMAGE_FSTYPES += "wic"
-WKS_FILE += "ledge-ti-am572x.wks.in"
+IMAGE_FSTYPES = "wic"
+WKS_FILE = "ledge-ti-am572x.wks.in"
 WIC_CREATE_EXTRA_ARGS += "--no-fstab-update"
 
 # for image generated on ext4, force UUID


### PR DESCRIPTION
Expression += adds wks file while if original from ti
was set ledge wks file was missing.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>