### PR TITLE
optee-os: drop remove allow-setting-sysroot-for-libgcc-lookup.patch

### DIFF
--- a/meta-ledge-sw/recipes-security/optee/optee-ftpm.bb
+++ b/meta-ledge-sw/recipes-security/optee/optee-ftpm.bb
@@ -29,12 +29,12 @@ OPTEE_CLIENT_EXPORT = "${STAGING_DIR_HOST}${prefix}"
 TEEC_EXPORT = "${STAGING_DIR_HOST}${prefix}"
 TA_DEV_KIT_DIR = "${STAGING_INCDIR}/optee/export-user_ta"
 
-EXTRA_OEMAKE += "\
+EXTRA_OEMAKE += '\
     CFG_FTPM_USE_WOLF=y \
     TA_DEV_KIT_DIR=${TA_DEV_KIT_DIR} \
     TA_CROSS_COMPILE=${TARGET_PREFIX} \
-    LIBGCC_LOCATE_CFLAGS=--sysroot=${STAGING_DIR_HOST} \
-"
+    CFLAGS="${CFLAGS} --sysroot=${STAGING_DIR_HOST}" \
+'
 
 EXTRA_OEMAKE_append_aarch64 = "\
     CFG_ARM64_ta_arm64=y \

--- a/meta-ledge-sw/recipes-security/optee/optee-ledge.bb
+++ b/meta-ledge-sw/recipes-security/optee/optee-ledge.bb
@@ -25,11 +25,11 @@ EXTRA_OEMAKE = " TA_DEV_KIT_DIR=${TA_DEV_KIT_DIR} \
                  HOST_CROSS_COMPILE=${TARGET_PREFIX} \
                  TA_CROSS_COMPILE=${TARGET_PREFIX} \
                  V=1 \
-                 LIBGCC_LOCATE_CFLAGS=--sysroot=${STAGING_DIR_HOST} \
                "
 
 B = "${S}"
 do_compile() {
+    export CFLAGS="${CFLAGS} --sysroot=${STAGING_DIR_HOST}"
     oe_runmake
 }
 


### PR DESCRIPTION
With changes in meta-linaro:
https://review.linaro.org/c/openembedded/meta-linaro/+/39634
drop sysroot patch from meta-ledge.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>