### PR TITLE
Hardknott libcamera SRCREV bump & Rockchip ipa improvements

### DIFF
--- a/meta-ledge-sw/recipes-multimedia/libcamera/libcamera.bbappend
+++ b/meta-ledge-sw/recipes-multimedia/libcamera/libcamera.bbappend
@@ -1,3 +1,6 @@
+
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
 SRCREV = "61670bb338dd4441b9d9dffdcd8849c2305eb4f3"
 
 PV = "202201+git${SRCPV}"
@@ -5,6 +8,15 @@ PV = "202201+git${SRCPV}"
 DEPENDS += " libevent"
 
 SRC_URI_remove = "file://0001-uvcvideo-Use-auto-variable-to-avoid-range-loop-warni.patch"
+
+SRC_URI_append = " \
+     file://0001-ipa-rkisp1-Introduce-sensor-degamma.patch \
+     file://0002-ipa-rkisp1-Use-frame-index.patch \
+     file://0003-ipa-rkisp1-Introduce-Black-Level-Correction.patch \
+     file://0004-ipa-rkisp1-Introduce-AWB.patch \
+     file://0005-ipa-rkisp1-Introduce-crosstalk-correction.patch \
+     file://0006-ipa-rkisp1-agc-Introduce-histogram-calculation.patch \
+"
 
 EXTRA_OEMESON = " \
      -Dpipelines=raspberrypi,rkisp1,uvcvideo -Dv4l2=true -Dcam=enabled \

--- a/meta-ledge-sw/recipes-multimedia/libcamera/libcamera.bbappend
+++ b/meta-ledge-sw/recipes-multimedia/libcamera/libcamera.bbappend
@@ -1,0 +1,23 @@
+SRCREV = "61670bb338dd4441b9d9dffdcd8849c2305eb4f3"
+
+PV = "202201+git${SRCPV}"
+
+DEPENDS += " libevent"
+
+SRC_URI_remove = "file://0001-uvcvideo-Use-auto-variable-to-avoid-range-loop-warni.patch"
+
+EXTRA_OEMESON = " \
+     -Dpipelines=raspberrypi,rkisp1,uvcvideo -Dv4l2=true -Dcam=enabled \
+     --buildtype=release -Dtest=false -Dlc-compliance=disabled -Ddocumentation=disabled \
+"
+
+FILES_${PN}-dev = "${includedir} ${libdir}/pkgconfig \
+                 ${libdir}/libcamera.so ${libdir}/libcamera-base.so"
+ 
+FILES_${PN} += " \
+     ${libdir}/libcamera.so.* \
+     ${libdir}/libcamera-base.so.* \
+     ${libdir}/v4l2-compat.so \
+     ${libexecdir}/${BPN}/* \
+     ${bindir}/cam \
+"

--- a/meta-ledge-sw/recipes-multimedia/libcamera/libcamera/0001-ipa-rkisp1-Introduce-sensor-degamma.patch
+++ b/meta-ledge-sw/recipes-multimedia/libcamera/libcamera/0001-ipa-rkisp1-Introduce-sensor-degamma.patch
@@ -1,0 +1,145 @@
+From 09bd16b68912e0c9d33102eed777221837f8e61d Mon Sep 17 00:00:00 2001
+From: Jean-Michel Hautbois <jeanmichel.hautbois@ideasonboard.com>
+Date: Thu, 2 Dec 2021 19:04:05 +0100
+Subject: [PATCH 1/6] ipa: rkisp1: Introduce sensor degamma
+
+The RkISP1 has a sensor degamma control. Introduce the algorithm, but
+only implement the prepare function as it is a static table to be set.
+The table used is the one found in the imx219 tuning data in RPi as this
+is the only sensor I have right now and it looks like a decent default
+table.
+
+Signed-off-by: Jean-Michel Hautbois <jeanmichel.hautbois@ideasonboard.com>
+---
+ src/ipa/rkisp1/algorithms/meson.build |  1 +
+ src/ipa/rkisp1/algorithms/sdg.cpp     | 49 +++++++++++++++++++++++++++
+ src/ipa/rkisp1/algorithms/sdg.h       | 30 ++++++++++++++++
+ src/ipa/rkisp1/rkisp1.cpp             |  2 ++
+ 4 files changed, 82 insertions(+)
+ create mode 100644 src/ipa/rkisp1/algorithms/sdg.cpp
+ create mode 100644 src/ipa/rkisp1/algorithms/sdg.h
+
+diff --git a/src/ipa/rkisp1/algorithms/meson.build b/src/ipa/rkisp1/algorithms/meson.build
+index a19c1a4f..0678518d 100644
+--- a/src/ipa/rkisp1/algorithms/meson.build
++++ b/src/ipa/rkisp1/algorithms/meson.build
+@@ -2,4 +2,5 @@
+ 
+ rkisp1_ipa_algorithms = files([
+     'agc.cpp',
++    'sdg.cpp',
+ ])
+diff --git a/src/ipa/rkisp1/algorithms/sdg.cpp b/src/ipa/rkisp1/algorithms/sdg.cpp
+new file mode 100644
+index 00000000..3f6b3e20
+--- /dev/null
++++ b/src/ipa/rkisp1/algorithms/sdg.cpp
+@@ -0,0 +1,49 @@
++/* SPDX-License-Identifier: LGPL-2.1-or-later */
++/*
++ * Copyright (C) 2021, Ideas On Board
++ *
++ * sdg.cpp - Sensor degamma control algorithm
++ */
++
++#include "sdg.h"
++
++/**
++ * \file sdg.h
++ */
++
++namespace libcamera {
++
++namespace ipa::rkisp1::algorithms {
++
++/**
++ * \class SensorDeGamma
++ * \brief A sensor degamma algorithm
++ */
++
++static const uint16_t imx219DeGammaCurve[] = { 0, 583, 957, 1299, 1609, 1877,
++					       2123, 2350, 2540, 2859, 3101, 3293,
++					       3429, 3666, 3823, 3963, 4095 };
++
++/**
++ * \copydoc libcamera::ipa::Algorithm::prepare
++ */
++void SensorDeGamma::prepare([[maybe_unused]] IPAContext &context,
++			    rkisp1_params_cfg *params)
++{
++	for (uint32_t i = 0; i < RKISP1_CIF_ISP_DEGAMMA_CURVE_SIZE; i++) {
++		params->others.sdg_config.curve_r.gamma_y[i] = imx219DeGammaCurve[i];
++		params->others.sdg_config.curve_b.gamma_y[i] = imx219DeGammaCurve[i];
++		params->others.sdg_config.curve_g.gamma_y[i] = imx219DeGammaCurve[i];
++	}
++
++	params->others.sdg_config.xa_pnts.gamma_dx0 = 0x44444444;
++	params->others.sdg_config.xa_pnts.gamma_dx1 = 0x44444444;
++
++	params->module_en_update |= RKISP1_CIF_ISP_MODULE_SDG;
++	params->module_ens |= RKISP1_CIF_ISP_MODULE_SDG;
++	params->module_cfg_update |= RKISP1_CIF_ISP_MODULE_SDG;
++}
++
++} /* namespace ipa::rkisp1::algorithms */
++
++} /* namespace libcamera */
+diff --git a/src/ipa/rkisp1/algorithms/sdg.h b/src/ipa/rkisp1/algorithms/sdg.h
+new file mode 100644
+index 00000000..24c41627
+--- /dev/null
++++ b/src/ipa/rkisp1/algorithms/sdg.h
+@@ -0,0 +1,30 @@
++/* SPDX-License-Identifier: LGPL-2.1-or-later */
++/*
++ * Copyright (C) 2021, Ideas On Board
++ *
++ * sdg.h - Sensor degamma control algorithm
++ */
++
++#pragma once
++
++#include <linux/rkisp1-config.h>
++
++#include "algorithm.h"
++
++namespace libcamera {
++
++struct IPACameraSensorInfo;
++
++namespace ipa::rkisp1::algorithms {
++
++class SensorDeGamma : public Algorithm
++{
++public:
++	SensorDeGamma() = default;
++	~SensorDeGamma() = default;
++
++	void prepare(IPAContext &context, rkisp1_params_cfg *params) override;
++};
++
++} /* namespace ipa::rkisp1::algorithms */
++} /* namespace libcamera */
+diff --git a/src/ipa/rkisp1/rkisp1.cpp b/src/ipa/rkisp1/rkisp1.cpp
+index 2d79f15f..07f1f1c8 100644
+--- a/src/ipa/rkisp1/rkisp1.cpp
++++ b/src/ipa/rkisp1/rkisp1.cpp
+@@ -27,6 +27,7 @@
+ 
+ #include "algorithms/agc.h"
+ #include "algorithms/algorithm.h"
++#include "algorithms/sdg.h"
+ #include "libipa/camera_sensor_helper.h"
+ 
+ #include "ipa_context.h"
+@@ -126,6 +127,7 @@ int IPARkISP1::init(const IPASettings &settings, unsigned int hwRevision)
+ 
+ 	/* Construct our Algorithms */
+ 	algorithms_.push_back(std::make_unique<algorithms::Agc>());
++	algorithms_.push_back(std::make_unique<algorithms::SensorDeGamma>());
+ 
+ 	return 0;
+ }
+-- 
+2.25.1
+

--- a/meta-ledge-sw/recipes-multimedia/libcamera/libcamera/0001-uvcvideo-Use-auto-variable-to-avoid-range-loop-warni.patch
+++ b/meta-ledge-sw/recipes-multimedia/libcamera/libcamera/0001-uvcvideo-Use-auto-variable-to-avoid-range-loop-warni.patch
@@ -1,0 +1,117 @@
+Delivered-To: raj.khem@gmail.com
+Received: by 2002:a05:620a:20d3:0:0:0:0 with SMTP id f19csp2716715qka;
+        Sat, 27 Mar 2021 19:58:30 -0700 (PDT)
+X-Google-Smtp-Source: ABdhPJwyDnjZqZmFqHVShb/5/RoVkJ4Avv5bcnyuo85vIRR2vJDQF+QBZpQpEWHgx5GuEuwLVSC+
+X-Received: by 2002:a05:6512:22d0:: with SMTP id g16mr12125441lfu.650.1616900310724;
+        Sat, 27 Mar 2021 19:58:30 -0700 (PDT)
+ARC-Seal: i=1; a=rsa-sha256; t=1616900310; cv=none;
+        d=google.com; s=arc-20160816;
+        b=bZlu68tossyE2YcGkt0HzIhqTUroWDT/EgJvAiQBgZ6bPzMJ+wjwWp3LzViqOxiRPQ
+         r0cFyme7CJ9YRf2TLmpjGuv2RPQ+EkrtFdlB7i65nhDrwvBoxt78vF2tUoDgVLL1YrU9
+         wKgHPtBjtDcDveOXKQJH2j5HRwiBjCXlPRBhlSxV8kJPBj//dRaKm0MsxfiW/IgyN1tZ
+         FFxfe4Lk1Awm8ZKAklhdKMly3MFA6IbnjwNcN/84a0R/0+PLu9X8XIR6+CnrfqSgWOBx
+         zsV8p3HuVQTpX7Hhnkiz7PYudHsJJ/7KXeXTP6s9NNnZGu9A6U/E6VOob5BSm9DDIA5z
+         4AnA==
+ARC-Message-Signature: i=1; a=rsa-sha256; c=relaxed/relaxed; d=google.com; s=arc-20160816;
+        h=content-transfer-encoding:mime-version:message-id:date:subject:cc
+         :to:from:dkim-signature;
+        bh=fbAn+wsNks5BGTY34H4T90NDFJaNV4nnt9vc9DBFaWQ=;
+        b=mLZNiQR/CdgcVTAc7OQmK0ZYTVpofG/EOqTIi2NYIYFhanWhatYY9Hx2xwxIp6kQ5R
+         n0uXh5tLth6aPYD09z3YcXYasEIszBKwoNUFjRA85lFm3d5/J2S1wC5rBy25QeCDOg57
+         QdzYrTBX2QGRHGQKauEnX5FLDTT+I53sPa87TyvxUKBS+lTAbJig70KfmL7FJIEWT1ZI
+         CZKCErYFlQTGNnwM0CYVXyHv54D2tA25veHQIJN8KK+XObNWuAY3rYpqKoUpOP4vpSPi
+         MXJWAV4L6NZEShWvwJiC4Zdy2xFzXASX27CAKIsX6T5Rub03grVTg6WVt9bChK1x5jeg
+         A2Yw==
+ARC-Authentication-Results: i=1; mx.google.com;
+       dkim=pass (test mode) header.i=@ideasonboard.com header.s=mail header.b=MniKswyT;
+       spf=pass (google.com: domain of laurent.pinchart@ideasonboard.com designates 213.167.242.64 as permitted sender) smtp.mailfrom=laurent.pinchart@ideasonboard.com
+Return-Path: <laurent.pinchart@ideasonboard.com>
+Received: from perceval.ideasonboard.com (perceval.ideasonboard.com. [213.167.242.64])
+        by mx.google.com with ESMTPS id v18si12339470ljj.208.2021.03.27.19.58.30
+        for <raj.khem@gmail.com>
+        (version=TLS1_3 cipher=TLS_AES_256_GCM_SHA384 bits=256/256);
+        Sat, 27 Mar 2021 19:58:30 -0700 (PDT)
+Received-SPF: pass (google.com: domain of laurent.pinchart@ideasonboard.com designates 213.167.242.64 as permitted sender) client-ip=213.167.242.64;
+Authentication-Results: mx.google.com;
+       dkim=pass (test mode) header.i=@ideasonboard.com header.s=mail header.b=MniKswyT;
+       spf=pass (google.com: domain of laurent.pinchart@ideasonboard.com designates 213.167.242.64 as permitted sender) smtp.mailfrom=laurent.pinchart@ideasonboard.com
+Received: from pendragon.lan (62-78-145-57.bb.dnainternet.fi [62.78.145.57])
+	by perceval.ideasonboard.com (Postfix) with ESMTPSA id 11F12332;
+	Sun, 28 Mar 2021 04:58:28 +0200 (CEST)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/simple; d=ideasonboard.com;
+	s=mail; t=1616900309;
+	bh=BwCg4h9N9fJysbMT1Yjbazbp7zTImD9mkWJSjCKzCmg=;
+	h=From:To:Cc:Subject:Date:From;
+	b=MniKswyT+aUtPgeMFeLqW6cRMFsPRN4W1XtVDA6pqI0QTSSx5koEuzSfEybjs6Qbp
+	 ZdQar1r5nBIRCg9uq85YoLKoFeT7WN4PrwnRYPwaYGAFHfV44rDrq4RBe3VOIb+85W
+	 tKn4HEzjlFelrImVbeymBsgpVhITveSVH1MdYRsE=
+From: Laurent Pinchart <laurent.pinchart@ideasonboard.com>
+To: libcamera-devel@lists.libcamera.org
+Cc: Khem Raj <raj.khem@gmail.com>
+Subject: [PATCH v2] libcamera: pipeline: uvcvideo: Avoid reference to temporary object
+Date: Sun, 28 Mar 2021 05:57:41 +0300
+Message-Id: <20210328025741.30246-1-laurent.pinchart@ideasonboard.com>
+X-Mailer: git-send-email 2.28.1
+MIME-Version: 1.0
+Content-Transfer-Encoding: 8bit
+
+From: Khem Raj <raj.khem@gmail.com>
+
+A range-based for loop whose range expression is an array of char
+pointers and range variable declaration is a const reference to a
+std::string creates a temporary string from the char pointer and binds
+the range variable reference to it. This creates a const reference to a
+temporary, which is valid in C++, and extends the lifetime of the
+temporary to the lifetime of the reference.
+
+However, lifetime extension in range-based for loops is considered as a
+sign of a potential issue, as a temporary is created for every
+iteration, which can be costly, and the usage of a reference in the
+range declaration doesn't make it obvious that the code isn't simply
+binding a reference to an existing object. gcc 11, with the
+-Wrange-loop-construct option, flags this:
+
+uvcvideo.cpp:432:33: error: loop variable 'name' of type 'const string&' {aka 'const std::__cxx11::basic_string<cha
+r>&'} binds to a temporary constructed from type 'const char* const' [-Werror=range-loop-construct]
+|   432 |         for (const std::string &name : { "idVendor", "idProduct" }) {
+|       |                                 ^~~~
+
+To please the compiler, make the range variable a const char *. This may
+bring a tiny performance improvement, as the name is only used once, in
+a location where the compiler can use
+
+	operator+(const std::string &, const char *)
+
+instead of
+
+	operator+(const std::string &, const std::string &)
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+Reviewed-by: Laurent Pinchart <laurent.pinchart@ideasonboard.com>
+
+Use a const char * type instead of auto, and update the commit message
+accordingly.
+
+Signed-off-by: Laurent Pinchart <laurent.pinchart@ideasonboard.com>
+---
+ src/libcamera/pipeline/uvcvideo/uvcvideo.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/libcamera/pipeline/uvcvideo/uvcvideo.cpp b/src/libcamera/pipeline/uvcvideo/uvcvideo.cpp
+index 031f96e28449..b6c6ade5ebaf 100644
+--- a/src/libcamera/pipeline/uvcvideo/uvcvideo.cpp
++++ b/src/libcamera/pipeline/uvcvideo/uvcvideo.cpp
+@@ -429,7 +429,7 @@ std::string PipelineHandlerUVC::generateId(const UVCCameraData *data)
+ 
+ 	/* Creata a device ID from the USB devices vendor and product ID. */
+ 	std::string deviceId;
+-	for (const std::string &name : { "idVendor", "idProduct" }) {
++	for (const char *name : { "idVendor", "idProduct" }) {
+ 		std::ifstream file(path + "/../" + name);
+ 
+ 		if (!file.is_open())
+-- 
+Regards,
+
+Laurent Pinchart
+

--- a/meta-ledge-sw/recipes-multimedia/libcamera/libcamera/0002-ipa-rkisp1-Use-frame-index.patch
+++ b/meta-ledge-sw/recipes-multimedia/libcamera/libcamera/0002-ipa-rkisp1-Use-frame-index.patch
@@ -1,0 +1,123 @@
+From d0b40e519f09b1390820165acedf0cf71feab6be Mon Sep 17 00:00:00 2001
+From: Jean-Michel Hautbois <jeanmichel.hautbois@ideasonboard.com>
+Date: Thu, 2 Dec 2021 19:04:06 +0100
+Subject: [PATCH 2/6] ipa: rkisp1: Use frame index
+
+Instead of incrementing the frameCount manually, use the frame index on
+the EventStatReay event and store it in a new IPAFrameContext variable
+named frameId.
+
+Signed-off-by: Jean-Michel Hautbois <jeanmichel.hautbois@ideasonboard.com>
+---
+ src/ipa/rkisp1/algorithms/agc.cpp |  5 ++---
+ src/ipa/rkisp1/ipa_context.cpp    |  5 +++++
+ src/ipa/rkisp1/ipa_context.h      |  2 ++
+ src/ipa/rkisp1/rkisp1.cpp         | 11 +++++------
+ 4 files changed, 14 insertions(+), 9 deletions(-)
+
+diff --git a/src/ipa/rkisp1/algorithms/agc.cpp b/src/ipa/rkisp1/algorithms/agc.cpp
+index dd97afc0..50980835 100644
+--- a/src/ipa/rkisp1/algorithms/agc.cpp
++++ b/src/ipa/rkisp1/algorithms/agc.cpp
+@@ -82,8 +82,6 @@ int Agc::configure(IPAContext &context,
+ 	else
+ 		numCells_ = RKISP1_CIF_ISP_AE_MEAN_MAX_V12;
+ 
+-	/* \todo Use actual frame index by populating it in the frameContext. */
+-	frameCount_ = 0;
+ 	return 0;
+ }
+ 
+@@ -255,6 +253,8 @@ void Agc::process(IPAContext &context, const rkisp1_stat_buffer *stats)
+ 
+ 	const rkisp1_cif_isp_ae_stat *ae = &params->ae;
+ 
++	frameCount_ = context.frameContext.frameId;
++
+ 	/*
+ 	 * Estimate the gain needed to achieve a relative luminance target. To
+ 	 * account for non-linearity caused by saturation, the value needs to be
+@@ -278,7 +278,6 @@ void Agc::process(IPAContext &context, const rkisp1_stat_buffer *stats)
+ 	}
+ 
+ 	computeExposure(context, yGain);
+-	frameCount_++;
+ }
+ 
+ void Agc::prepare([[maybe_unused]] IPAContext &context,
+diff --git a/src/ipa/rkisp1/ipa_context.cpp b/src/ipa/rkisp1/ipa_context.cpp
+index 9cb2a9fd..992c9225 100644
+--- a/src/ipa/rkisp1/ipa_context.cpp
++++ b/src/ipa/rkisp1/ipa_context.cpp
+@@ -113,4 +113,9 @@ namespace libcamera::ipa::rkisp1 {
+  * \brief Analogue gain multiplier
+  */
+ 
++/**
++ * \var IPAFrameContext::frameId
++ * \brief Frame number for this frame context
++ */
++
+ } /* namespace libcamera::ipa::rkisp1 */
+diff --git a/src/ipa/rkisp1/ipa_context.h b/src/ipa/rkisp1/ipa_context.h
+index b94ade0c..c447369f 100644
+--- a/src/ipa/rkisp1/ipa_context.h
++++ b/src/ipa/rkisp1/ipa_context.h
+@@ -43,6 +43,8 @@ struct IPAFrameContext {
+ 		uint32_t exposure;
+ 		double gain;
+ 	} sensor;
++
++	unsigned int frameId;
+ };
+ 
+ struct IPAContext {
+diff --git a/src/ipa/rkisp1/rkisp1.cpp b/src/ipa/rkisp1/rkisp1.cpp
+index 07f1f1c8..cd425a2e 100644
+--- a/src/ipa/rkisp1/rkisp1.cpp
++++ b/src/ipa/rkisp1/rkisp1.cpp
+@@ -57,8 +57,7 @@ public:
+ private:
+ 	void queueRequest(unsigned int frame, rkisp1_params_cfg *params,
+ 			  const ControlList &controls);
+-	void updateStatistics(unsigned int frame,
+-			      const rkisp1_stat_buffer *stats);
++	void updateStatistics(const rkisp1_stat_buffer *stats);
+ 
+ 	void setControls(unsigned int frame);
+ 	void metadataReady(unsigned int frame, unsigned int aeState);
+@@ -241,7 +240,6 @@ void IPARkISP1::processEvent(const RkISP1Event &event)
+ {
+ 	switch (event.op) {
+ 	case EventSignalStatBuffer: {
+-		unsigned int frame = event.frame;
+ 		unsigned int bufferId = event.bufferId;
+ 
+ 		const rkisp1_stat_buffer *stats =
+@@ -252,8 +250,9 @@ void IPARkISP1::processEvent(const RkISP1Event &event)
+ 			event.sensorControls.get(V4L2_CID_EXPOSURE).get<int32_t>();
+ 		context_.frameContext.sensor.gain =
+ 			camHelper_->gain(event.sensorControls.get(V4L2_CID_ANALOGUE_GAIN).get<int32_t>());
++		context_.frameContext.frameId = event.frame;
+ 
+-		updateStatistics(frame, stats);
++		updateStatistics(stats);
+ 		break;
+ 	}
+ 	case EventQueueRequest: {
+@@ -288,10 +287,10 @@ void IPARkISP1::queueRequest(unsigned int frame, rkisp1_params_cfg *params,
+ 	queueFrameAction.emit(frame, op);
+ }
+ 
+-void IPARkISP1::updateStatistics(unsigned int frame,
+-				 const rkisp1_stat_buffer *stats)
++void IPARkISP1::updateStatistics(const rkisp1_stat_buffer *stats)
+ {
+ 	unsigned int aeState = 0;
++	unsigned int frame = context_.frameContext.frameId;
+ 
+ 	for (auto const &algo : algorithms_)
+ 		algo->process(context_, stats);
+-- 
+2.25.1
+

--- a/meta-ledge-sw/recipes-multimedia/libcamera/libcamera/0003-ipa-rkisp1-Introduce-Black-Level-Correction.patch
+++ b/meta-ledge-sw/recipes-multimedia/libcamera/libcamera/0003-ipa-rkisp1-Introduce-Black-Level-Correction.patch
@@ -1,0 +1,150 @@
+From f2cb71fc8a2f76779eebb0b748cad37bc11fcef9 Mon Sep 17 00:00:00 2001
+From: Jean-Michel Hautbois <jeanmichel.hautbois@ideasonboard.com>
+Date: Thu, 2 Dec 2021 19:04:07 +0100
+Subject: [PATCH 3/6] ipa: rkisp1: Introduce Black Level Correction
+
+In order to have the proper pixel levels, apply a fixed black level
+correction, based on the imx219 tuning file in RPi. The value is 4096 on
+16 bits, and the pipeline for RkISP1 is on 12 bits, scale it.
+
+Signed-off-by: Jean-Michel Hautbois <jeanmichel.hautbois@ideasonboard.com>
+---
+ src/ipa/rkisp1/algorithms/blc.cpp     | 55 +++++++++++++++++++++++++++
+ src/ipa/rkisp1/algorithms/blc.h       | 30 +++++++++++++++
+ src/ipa/rkisp1/algorithms/meson.build |  1 +
+ src/ipa/rkisp1/rkisp1.cpp             |  2 +
+ 4 files changed, 88 insertions(+)
+ create mode 100644 src/ipa/rkisp1/algorithms/blc.cpp
+ create mode 100644 src/ipa/rkisp1/algorithms/blc.h
+
+diff --git a/src/ipa/rkisp1/algorithms/blc.cpp b/src/ipa/rkisp1/algorithms/blc.cpp
+new file mode 100644
+index 00000000..f27a8e43
+--- /dev/null
++++ b/src/ipa/rkisp1/algorithms/blc.cpp
+@@ -0,0 +1,55 @@
++/* SPDX-License-Identifier: LGPL-2.1-or-later */
++/*
++ * Copyright (C) 2021, Ideas On Board
++ *
++ * blc.cpp - RkISP1 Black Level Correction control
++ */
++
++#include "blc.h"
++
++/**
++ * \file blc.h
++ */
++
++namespace libcamera {
++
++namespace ipa::rkisp1::algorithms {
++
++/**
++ * \class BlackLevelCorrection
++ * \brief RkISP1 Black Level Correction control
++ *
++ * The pixels output by the camera normally include a black level, because
++ * sensors do not always report a signal level of '0' for black. Pixels at or
++ * below this level should be considered black. To achieve that, the RkISP BLC
++ * algorithm subtracts a configurable offset from all pixels.
++ *
++ * The black level can be measured at runtime from an optical dark region of the
++ * camera sensor, or measured during the camera tuning process. The first option
++ * isn't currently supported.
++ */
++
++/**
++ * \copydoc libcamera::ipa::Algorithm::prepare
++ */
++void BlackLevelCorrection::prepare([[maybe_unused]] IPAContext &context,
++				   rkisp1_params_cfg *params)
++{
++	/*
++	 * Substract fixed values taken from imx219 tuning file.
++	 * \todo Use a configuration file for it ?
++	 */
++	params->others.bls_config.enable_auto = 0;
++	params->others.bls_config.fixed_val.r = 256;
++	params->others.bls_config.fixed_val.gr = 256;
++	params->others.bls_config.fixed_val.gb = 256;
++	params->others.bls_config.fixed_val.b = 256;
++
++	params->module_en_update |= RKISP1_CIF_ISP_MODULE_BLS;
++	params->module_ens |= RKISP1_CIF_ISP_MODULE_BLS;
++	params->module_cfg_update |= RKISP1_CIF_ISP_MODULE_BLS;
++}
++
++} /* namespace ipa::rkisp1::algorithms */
++
++} /* namespace libcamera */
+diff --git a/src/ipa/rkisp1/algorithms/blc.h b/src/ipa/rkisp1/algorithms/blc.h
+new file mode 100644
+index 00000000..331a2209
+--- /dev/null
++++ b/src/ipa/rkisp1/algorithms/blc.h
+@@ -0,0 +1,30 @@
++/* SPDX-License-Identifier: LGPL-2.1-or-later */
++/*
++ * Copyright (C) 2021, Ideas On Board
++ *
++ * blc.h - RkISP1 Black Level Correction control
++ */
++
++#pragma once
++
++#include <linux/rkisp1-config.h>
++
++#include "algorithm.h"
++
++namespace libcamera {
++
++struct IPACameraSensorInfo;
++
++namespace ipa::rkisp1::algorithms {
++
++class BlackLevelCorrection : public Algorithm
++{
++public:
++	BlackLevelCorrection() = default;
++	~BlackLevelCorrection() = default;
++
++	void prepare(IPAContext &context, rkisp1_params_cfg *params) override;
++};
++
++} /* namespace ipa::rkisp1::algorithms */
++} /* namespace libcamera */
+diff --git a/src/ipa/rkisp1/algorithms/meson.build b/src/ipa/rkisp1/algorithms/meson.build
+index 0678518d..e6767aa5 100644
+--- a/src/ipa/rkisp1/algorithms/meson.build
++++ b/src/ipa/rkisp1/algorithms/meson.build
+@@ -2,5 +2,6 @@
+ 
+ rkisp1_ipa_algorithms = files([
+     'agc.cpp',
++    'blc.cpp',
+     'sdg.cpp',
+ ])
+diff --git a/src/ipa/rkisp1/rkisp1.cpp b/src/ipa/rkisp1/rkisp1.cpp
+index cd425a2e..ec879ba3 100644
+--- a/src/ipa/rkisp1/rkisp1.cpp
++++ b/src/ipa/rkisp1/rkisp1.cpp
+@@ -27,6 +27,7 @@
+ 
+ #include "algorithms/agc.h"
+ #include "algorithms/algorithm.h"
++#include "algorithms/blc.h"
+ #include "algorithms/sdg.h"
+ #include "libipa/camera_sensor_helper.h"
+ 
+@@ -126,6 +127,7 @@ int IPARkISP1::init(const IPASettings &settings, unsigned int hwRevision)
+ 
+ 	/* Construct our Algorithms */
+ 	algorithms_.push_back(std::make_unique<algorithms::Agc>());
++	algorithms_.push_back(std::make_unique<algorithms::BlackLevelCorrection>());
+ 	algorithms_.push_back(std::make_unique<algorithms::SensorDeGamma>());
+ 
+ 	return 0;
+-- 
+2.25.1
+

--- a/meta-ledge-sw/recipes-multimedia/libcamera/libcamera/0004-ipa-rkisp1-Introduce-AWB.patch
+++ b/meta-ledge-sw/recipes-multimedia/libcamera/libcamera/0004-ipa-rkisp1-Introduce-AWB.patch
@@ -1,0 +1,343 @@
+From 24a3f9e55ca84ecb6f58657be6ae31fc0d7cdff8 Mon Sep 17 00:00:00 2001
+From: Jean-Michel Hautbois <jeanmichel.hautbois@ideasonboard.com>
+Date: Thu, 2 Dec 2021 19:04:08 +0100
+Subject: [PATCH 4/6] ipa: rkisp1: Introduce AWB
+
+The RkISP1 ISP calculates a mean value for Y, Cr and Cb at each frame.
+There is a RGB mode which could theoretically give us the values for R,
+G and B directly, but it seems to be failing right now.
+
+Convert those values into R, G and B and estimate the gain to apply in a
+grey world.
+
+Signed-off-by: Jean-Michel Hautbois <jeanmichel.hautbois@ideasonboard.com>
+---
+ src/ipa/rkisp1/algorithms/awb.cpp     | 149 ++++++++++++++++++++++++++
+ src/ipa/rkisp1/algorithms/awb.h       |  33 ++++++
+ src/ipa/rkisp1/algorithms/meson.build |   1 +
+ src/ipa/rkisp1/ipa_context.cpp        |  28 +++++
+ src/ipa/rkisp1/ipa_context.h          |  17 +++
+ src/ipa/rkisp1/rkisp1.cpp             |   2 +
+ 6 files changed, 230 insertions(+)
+ create mode 100644 src/ipa/rkisp1/algorithms/awb.cpp
+ create mode 100644 src/ipa/rkisp1/algorithms/awb.h
+
+diff --git a/src/ipa/rkisp1/algorithms/awb.cpp b/src/ipa/rkisp1/algorithms/awb.cpp
+new file mode 100644
+index 00000000..0ec94764
+--- /dev/null
++++ b/src/ipa/rkisp1/algorithms/awb.cpp
+@@ -0,0 +1,149 @@
++/* SPDX-License-Identifier: LGPL-2.1-or-later */
++/*
++ * Copyright (C) 2021, Ideas On Board
++ *
++ * awb.cpp - AWB control algorithm
++ */
++
++#include "awb.h"
++
++#include <algorithm>
++#include <cmath>
++
++#include <libcamera/base/log.h>
++
++#include <libcamera/ipa/core_ipa_interface.h>
++
++/**
++ * \file awb.h
++ */
++
++namespace libcamera {
++
++namespace ipa::rkisp1::algorithms {
++
++/**
++ * \class Awb
++ * \brief A Grey world white balance correction algorithm
++ */
++
++LOG_DEFINE_CATEGORY(RkISP1Awb)
++
++/**
++ * \copydoc libcamera::ipa::Algorithm::configure
++ */
++int Awb::configure(IPAContext &context,
++		   const IPACameraSensorInfo &configInfo)
++{
++	context.frameContext.awb.gains.red = 1.0;
++	context.frameContext.awb.gains.blue = 1.0;
++	context.frameContext.awb.gains.green = 1.0;
++
++	/* Define the measurement window for AGC. */
++	context.configuration.awb.measureWindow.h_offs = configInfo.outputSize.width / 8;
++	context.configuration.awb.measureWindow.v_offs = configInfo.outputSize.height / 8;
++	context.configuration.awb.measureWindow.h_size = 3 * configInfo.outputSize.width / 4;
++	context.configuration.awb.measureWindow.v_size = 3 * configInfo.outputSize.height / 4;
++
++	return 0;
++}
++
++uint32_t Awb::estimateCCT(double red, double green, double blue)
++{
++	/* Convert the RGB values to CIE tristimulus values (XYZ) */
++	double X = (-0.14282) * (red) + (1.54924) * (green) + (-0.95641) * (blue);
++	double Y = (-0.32466) * (red) + (1.57837) * (green) + (-0.73191) * (blue);
++	double Z = (-0.68202) * (red) + (0.77073) * (green) + (0.56332) * (blue);
++
++	/* Calculate the normalized chromaticity values */
++	double x = X / (X + Y + Z);
++	double y = Y / (X + Y + Z);
++
++	/* Calculate CCT */
++	double n = (x - 0.3320) / (0.1858 - y);
++	return 449 * n * n * n + 3525 * n * n + 6823.3 * n + 5520.33;
++}
++
++/**
++ * \copydoc libcamera::ipa::Algorithm::process
++ */
++void Awb::process([[maybe_unused]] IPAContext &context, const rkisp1_stat_buffer *stats)
++{
++	const rkisp1_cif_isp_stat *params = &stats->params;
++	const rkisp1_cif_isp_awb_stat *awb = &params->awb;
++
++	/* Get the YCbCr mean values */
++	double yMean = awb->awb_mean[0].mean_y_or_g;
++	double crMean = awb->awb_mean[0].mean_cr_or_r;
++	double cbMean = awb->awb_mean[0].mean_cb_or_b;
++
++	/* Convert from YCbCr to RGB. */
++	double redMean = yMean + 1.402 * (crMean - 128);
++	double blueMean = yMean + 1.772 * (cbMean - 128);
++	double greenMean = yMean - 0.34414 * (cbMean - 128) - 0.71414 * (crMean - 128);
++
++	/* Estimate the red and blue gains to apply in a grey world. */
++	double redGain = greenMean / (redMean + 1);
++	double blueGain = greenMean / (blueMean + 1);
++
++	/* Filter the values to avoid oscillations. */
++	IPAFrameContext &frameContext = context.frameContext;
++
++	frameContext.awb.temperatureK = estimateCCT(redMean, greenMean, blueMean);
++	frameContext.awb.gains.red = 0.2 * redGain +
++				     0.8 * frameContext.awb.gains.red;
++	frameContext.awb.gains.blue = 0.2 * blueGain +
++				      0.8 * frameContext.awb.gains.blue;
++	/* Hardcode the green gain to 1.0. */
++	frameContext.awb.gains.green = 1.0;
++
++	LOG(RkISP1Awb, Debug) << "Gain found for red: " << context.frameContext.awb.gains.red
++			      << " and for blue: " << context.frameContext.awb.gains.blue;
++}
++
++/**
++ * \copydoc libcamera::ipa::Algorithm::prepare
++ */
++void Awb::prepare([[maybe_unused]] IPAContext &context,
++		  rkisp1_params_cfg *params)
++{
++	params->others.awb_gain_config.gain_green_b = 256 * context.frameContext.awb.gains.green;
++	params->others.awb_gain_config.gain_blue = 256 * context.frameContext.awb.gains.blue;
++	params->others.awb_gain_config.gain_red = 256 * context.frameContext.awb.gains.red;
++	params->others.awb_gain_config.gain_green_r = 256 * context.frameContext.awb.gains.green;
++
++	/* Configure the gains to apply. */
++	params->module_en_update |= RKISP1_CIF_ISP_MODULE_AWB_GAIN;
++	/* Update the ISP to apply the gains configured. */
++	params->module_ens |= RKISP1_CIF_ISP_MODULE_AWB_GAIN;
++	params->module_cfg_update |= RKISP1_CIF_ISP_MODULE_AWB_GAIN;
++
++	/* Configure the measure window for AWB. */
++	params->meas.awb_meas_config.awb_wnd = context.configuration.awb.measureWindow;
++	/*
++	 * Measure Y, Cr and Cb means.
++	 * \todo RGB is not working, the kernel seems to not configure it ?
++	 */
++	params->meas.awb_meas_config.awb_mode = RKISP1_CIF_ISP_AWB_MODE_YCBCR;
++	/* Reference Cr and Cb. */
++	params->meas.awb_meas_config.awb_ref_cb = 128;
++	params->meas.awb_meas_config.awb_ref_cr = 128;
++	/* Y values to include are between min_y and max_y only. */
++	params->meas.awb_meas_config.min_y = 16;
++	params->meas.awb_meas_config.max_y = 250;
++	/* Maximum Cr+Cb value to take into account for awb. */
++	params->meas.awb_meas_config.max_csum = 250;
++	/* Minimum Cr and Cb values to take into account. */
++	params->meas.awb_meas_config.min_c = 16;
++	/* Number of frames to use to estimate the mean (0 means 1 frame). */
++	params->meas.awb_meas_config.frames = 0;
++	/* Update AWB measurement unit configuration. */
++	params->module_cfg_update |= RKISP1_CIF_ISP_MODULE_AWB;
++	/* Make sure the ISP is measuring the means for the next frame. */
++	params->module_en_update |= RKISP1_CIF_ISP_MODULE_AWB;
++	params->module_ens |= RKISP1_CIF_ISP_MODULE_AWB;
++}
++
++} /* namespace ipa::rkisp1::algorithms */
++
++} /* namespace libcamera */
+diff --git a/src/ipa/rkisp1/algorithms/awb.h b/src/ipa/rkisp1/algorithms/awb.h
+new file mode 100644
+index 00000000..0a9fb82c
+--- /dev/null
++++ b/src/ipa/rkisp1/algorithms/awb.h
+@@ -0,0 +1,33 @@
++/* SPDX-License-Identifier: LGPL-2.1-or-later */
++/*
++ * Copyright (C) 2021, Ideas On Board
++ *
++ * awb.h - AWB control algorithm
++ */
++
++#pragma once
++
++#include <linux/rkisp1-config.h>
++
++#include "algorithm.h"
++
++namespace libcamera {
++
++namespace ipa::rkisp1::algorithms {
++
++class Awb : public Algorithm
++{
++public:
++	Awb() = default;
++	~Awb() = default;
++
++	int configure(IPAContext &context, const IPACameraSensorInfo &configInfo) override;
++	void prepare(IPAContext &context, rkisp1_params_cfg *params) override;
++	void process(IPAContext &context, const rkisp1_stat_buffer *stats) override;
++
++private:
++	uint32_t estimateCCT(double red, double green, double blue);
++};
++
++} /* namespace ipa::rkisp1::algorithms */
++} /* namespace libcamera */
+diff --git a/src/ipa/rkisp1/algorithms/meson.build b/src/ipa/rkisp1/algorithms/meson.build
+index e6767aa5..faec0eb3 100644
+--- a/src/ipa/rkisp1/algorithms/meson.build
++++ b/src/ipa/rkisp1/algorithms/meson.build
+@@ -2,6 +2,7 @@
+ 
+ rkisp1_ipa_algorithms = files([
+     'agc.cpp',
++    'awb.cpp',
+     'blc.cpp',
+     'sdg.cpp',
+ ])
+diff --git a/src/ipa/rkisp1/ipa_context.cpp b/src/ipa/rkisp1/ipa_context.cpp
+index 992c9225..2f53eb2f 100644
+--- a/src/ipa/rkisp1/ipa_context.cpp
++++ b/src/ipa/rkisp1/ipa_context.cpp
+@@ -78,6 +78,14 @@ namespace libcamera::ipa::rkisp1 {
+  * \brief Hardware revision of the ISP
+  */
+ 
++/**
++ * \var IPASessionConfiguration::awb
++ * \brief AWB parameters configuration of the IPA
++ *
++ * \var IPASessionConfiguration::awb.measureWindow
++ * \brief AWB measure window
++ */
++
+ /**
+  * \var IPASessionConfiguration::sensor
+  * \brief Sensor-specific configuration of the IPA
+@@ -102,6 +110,26 @@ namespace libcamera::ipa::rkisp1 {
+  * The gain should be adapted to the sensor specific gain code before applying.
+  */
+ 
++/**
++ * \var IPAFrameContext::awb
++ * \brief Context for the Automatic White Balance algorithm
++ *
++ * \struct IPAFrameContext::awb.gains
++ * \brief White balance gains
++ *
++ * \var IPAFrameContext::awb.gains.red
++ * \brief White balance gain for R channel
++ *
++ * \var IPAFrameContext::awb.gains.green
++ * \brief White balance gain for G channel
++ *
++ * \var IPAFrameContext::awb.gains.blue
++ * \brief White balance gain for B channel
++ *
++ * \var IPAFrameContext::awb.temperatureK
++ * \brief Estimated color temperature
++ */
++
+ /**
+  * \var IPAFrameContext::sensor
+  * \brief Effective sensor values
+diff --git a/src/ipa/rkisp1/ipa_context.h b/src/ipa/rkisp1/ipa_context.h
+index c447369f..51eae8b6 100644
+--- a/src/ipa/rkisp1/ipa_context.h
++++ b/src/ipa/rkisp1/ipa_context.h
+@@ -12,6 +12,8 @@
+ 
+ #include <libcamera/base/utils.h>
+ 
++#include <libcamera/geometry.h>
++
+ namespace libcamera {
+ 
+ namespace ipa::rkisp1 {
+@@ -22,8 +24,13 @@ struct IPASessionConfiguration {
+ 		utils::Duration maxShutterSpeed;
+ 		double minAnalogueGain;
+ 		double maxAnalogueGain;
++		struct rkisp1_cif_isp_window measureWindow;
+ 	} agc;
+ 
++	struct {
++		struct rkisp1_cif_isp_window measureWindow;
++	} awb;
++
+ 	struct {
+ 		utils::Duration lineDuration;
+ 	} sensor;
+@@ -39,6 +46,16 @@ struct IPAFrameContext {
+ 		double gain;
+ 	} agc;
+ 
++	struct {
++		struct {
++			double red;
++			double green;
++			double blue;
++		} gains;
++
++		double temperatureK;
++	} awb;
++
+ 	struct {
+ 		uint32_t exposure;
+ 		double gain;
+diff --git a/src/ipa/rkisp1/rkisp1.cpp b/src/ipa/rkisp1/rkisp1.cpp
+index ec879ba3..979f2842 100644
+--- a/src/ipa/rkisp1/rkisp1.cpp
++++ b/src/ipa/rkisp1/rkisp1.cpp
+@@ -27,6 +27,7 @@
+ 
+ #include "algorithms/agc.h"
+ #include "algorithms/algorithm.h"
++#include "algorithms/awb.h"
+ #include "algorithms/blc.h"
+ #include "algorithms/sdg.h"
+ #include "libipa/camera_sensor_helper.h"
+@@ -127,6 +128,7 @@ int IPARkISP1::init(const IPASettings &settings, unsigned int hwRevision)
+ 
+ 	/* Construct our Algorithms */
+ 	algorithms_.push_back(std::make_unique<algorithms::Agc>());
++	algorithms_.push_back(std::make_unique<algorithms::Awb>());
+ 	algorithms_.push_back(std::make_unique<algorithms::BlackLevelCorrection>());
+ 	algorithms_.push_back(std::make_unique<algorithms::SensorDeGamma>());
+ 
+-- 
+2.25.1
+

--- a/meta-ledge-sw/recipes-multimedia/libcamera/libcamera/0005-ipa-rkisp1-Introduce-crosstalk-correction.patch
+++ b/meta-ledge-sw/recipes-multimedia/libcamera/libcamera/0005-ipa-rkisp1-Introduce-crosstalk-correction.patch
@@ -1,0 +1,153 @@
+From 5ff50c69028dfc3bb2abd5b525f8cc40b0c9f5e5 Mon Sep 17 00:00:00 2001
+From: Jean-Michel Hautbois <jeanmichel.hautbois@ideasonboard.com>
+Date: Thu, 2 Dec 2021 19:04:09 +0100
+Subject: [PATCH 5/6] ipa: rkisp1: Introduce crosstalk correction
+
+Introduce the color correction matrix for the RkISP1 based on a simple
+assumptions on the gains until we can tune the sensor properly.
+
+Signed-off-by: Jean-Michel Hautbois <jeanmichel.hautbois@ideasonboard.com>
+---
+ src/ipa/rkisp1/algorithms/ctk.cpp     | 59 +++++++++++++++++++++++++++
+ src/ipa/rkisp1/algorithms/ctk.h       | 30 ++++++++++++++
+ src/ipa/rkisp1/algorithms/meson.build |  1 +
+ src/ipa/rkisp1/rkisp1.cpp             |  2 +
+ 4 files changed, 92 insertions(+)
+ create mode 100644 src/ipa/rkisp1/algorithms/ctk.cpp
+ create mode 100644 src/ipa/rkisp1/algorithms/ctk.h
+
+diff --git a/src/ipa/rkisp1/algorithms/ctk.cpp b/src/ipa/rkisp1/algorithms/ctk.cpp
+new file mode 100644
+index 00000000..81600e77
+--- /dev/null
++++ b/src/ipa/rkisp1/algorithms/ctk.cpp
+@@ -0,0 +1,59 @@
++/* SPDX-License-Identifier: LGPL-2.1-or-later */
++/*
++ * Copyright (C) 2021, Ideas On Board
++ *
++ * ctk.cpp - RkISP1 Cross-Talk Correction control
++ */
++
++#include "ctk.h"
++
++/**
++ * \file ctk.h
++ */
++
++namespace libcamera {
++
++namespace ipa::rkisp1::algorithms {
++
++/**
++ * \class CrossTalkCorrection
++ * \brief RkISP1 Cross-Talk Correction control (color correction matrix)
++ *
++ * The crosstalk in image sensor is an effect when signal from a specific pixel
++ * is affected by its adjacent pixels. An image sensor can be considered as a
++ * linear system, with linear crosstalk existing only between horizontal and
++ * vertical neighboring pixels. This matrix should be calculated based on tuning
++ * but a first approximation can be obtained by using the grey-world gains and
++ * applying them to their respective channel.
++ */
++
++/**
++ * \copydoc libcamera::ipa::Algorithm::prepare
++ */
++void CrossTalkCorrection::prepare([[maybe_unused]] IPAContext &context,
++				  rkisp1_params_cfg *params)
++{
++	params->others.ctk_config.coeff[0][0] = 128 * context.frameContext.awb.gains.red;
++	params->others.ctk_config.coeff[0][1] = 0;
++	params->others.ctk_config.coeff[0][2] = 0;
++
++	params->others.ctk_config.coeff[1][0] = 0;
++	params->others.ctk_config.coeff[1][1] = 128 * context.frameContext.awb.gains.green;
++	params->others.ctk_config.coeff[1][2] = 0;
++
++	params->others.ctk_config.coeff[2][0] = 0;
++	params->others.ctk_config.coeff[2][1] = 0;
++	params->others.ctk_config.coeff[2][2] = 128 * context.frameContext.awb.gains.blue;
++
++	params->others.ctk_config.ct_offset[0] = 0;
++	params->others.ctk_config.ct_offset[1] = 0;
++	params->others.ctk_config.ct_offset[2] = 0;
++
++	params->module_en_update |= RKISP1_CIF_ISP_MODULE_CTK;
++	params->module_ens |= RKISP1_CIF_ISP_MODULE_CTK;
++	params->module_cfg_update |= RKISP1_CIF_ISP_MODULE_CTK;
++}
++
++} /* namespace ipa::rkisp1::algorithms */
++
++} /* namespace libcamera */
+diff --git a/src/ipa/rkisp1/algorithms/ctk.h b/src/ipa/rkisp1/algorithms/ctk.h
+new file mode 100644
+index 00000000..c4d240e2
+--- /dev/null
++++ b/src/ipa/rkisp1/algorithms/ctk.h
+@@ -0,0 +1,30 @@
++/* SPDX-License-Identifier: LGPL-2.1-or-later */
++/*
++ * Copyright (C) 2021, Ideas On Board
++ *
++ * blc.h - RkISP1 Cross-Talk Correction control
++ */
++
++#pragma once
++
++#include <linux/rkisp1-config.h>
++
++#include "algorithm.h"
++
++namespace libcamera {
++
++struct IPACameraSensorInfo;
++
++namespace ipa::rkisp1::algorithms {
++
++class CrossTalkCorrection : public Algorithm
++{
++public:
++	CrossTalkCorrection() = default;
++	~CrossTalkCorrection() = default;
++
++	void prepare(IPAContext &context, rkisp1_params_cfg *params) override;
++};
++
++} /* namespace ipa::rkisp1::algorithms */
++} /* namespace libcamera */
+diff --git a/src/ipa/rkisp1/algorithms/meson.build b/src/ipa/rkisp1/algorithms/meson.build
+index faec0eb3..482e8847 100644
+--- a/src/ipa/rkisp1/algorithms/meson.build
++++ b/src/ipa/rkisp1/algorithms/meson.build
+@@ -4,5 +4,6 @@ rkisp1_ipa_algorithms = files([
+     'agc.cpp',
+     'awb.cpp',
+     'blc.cpp',
++    'ctk.cpp',
+     'sdg.cpp',
+ ])
+diff --git a/src/ipa/rkisp1/rkisp1.cpp b/src/ipa/rkisp1/rkisp1.cpp
+index 979f2842..21a9d15b 100644
+--- a/src/ipa/rkisp1/rkisp1.cpp
++++ b/src/ipa/rkisp1/rkisp1.cpp
+@@ -29,6 +29,7 @@
+ #include "algorithms/algorithm.h"
+ #include "algorithms/awb.h"
+ #include "algorithms/blc.h"
++#include "algorithms/ctk.h"
+ #include "algorithms/sdg.h"
+ #include "libipa/camera_sensor_helper.h"
+ 
+@@ -130,6 +131,7 @@ int IPARkISP1::init(const IPASettings &settings, unsigned int hwRevision)
+ 	algorithms_.push_back(std::make_unique<algorithms::Agc>());
+ 	algorithms_.push_back(std::make_unique<algorithms::Awb>());
+ 	algorithms_.push_back(std::make_unique<algorithms::BlackLevelCorrection>());
++	algorithms_.push_back(std::make_unique<algorithms::CrossTalkCorrection>());
+ 	algorithms_.push_back(std::make_unique<algorithms::SensorDeGamma>());
+ 
+ 	return 0;
+-- 
+2.25.1
+

--- a/meta-ledge-sw/recipes-multimedia/libcamera/libcamera/0006-ipa-rkisp1-agc-Introduce-histogram-calculation.patch
+++ b/meta-ledge-sw/recipes-multimedia/libcamera/libcamera/0006-ipa-rkisp1-agc-Introduce-histogram-calculation.patch
@@ -1,0 +1,243 @@
+From 2bfea573987d7d8adb7cb4026c9c6c0f660b28f1 Mon Sep 17 00:00:00 2001
+From: Jean-Michel Hautbois <jeanmichel.hautbois@ideasonboard.com>
+Date: Thu, 2 Dec 2021 19:04:10 +0100
+Subject: [PATCH 6/6] ipa: rkisp1: agc: Introduce histogram calculation
+
+As for the IPU3, we can estimate the histogram of the luminance. The
+RkISP1 can estimate multiple ones, the R, G and B ones, the Y only one
+and a combination of RGB. The one we are interested by in AGC is the Y
+histogram.
+
+Use the hardware revision to determine the number of bins of the
+produced histogram, and use it to populate a vector passed down to the
+libipa::Histogram class.
+
+As the sensor deGamma and AWB are applied, we also need to get back to
+the relative luminance value of 0.16, as for the IPU3.
+
+[griffinp] fixed up std::abs to utils::abs_diff hunk
+- 	if (utils::abs_diff(yGain, 1.0) < 0.01)
++	if (utils::abs_diff(evGain, 1.0) < 0.01)
+
+Signed-off-by: Jean-Michel Hautbois <jeanmichel.hautbois@ideasonboard.com>
+---
+ src/ipa/rkisp1/algorithms/agc.cpp | 87 ++++++++++++++++++++++++++-----
+ src/ipa/rkisp1/algorithms/agc.h   |  4 +-
+ 2 files changed, 77 insertions(+), 14 deletions(-)
+
+diff --git a/src/ipa/rkisp1/algorithms/agc.cpp b/src/ipa/rkisp1/algorithms/agc.cpp
+index 50980835..7aac5ba4 100644
+--- a/src/ipa/rkisp1/algorithms/agc.cpp
++++ b/src/ipa/rkisp1/algorithms/agc.cpp
+@@ -16,6 +16,8 @@
+ 
+ #include <libcamera/ipa/core_ipa_interface.h>
+ 
++#include "libipa/histogram.h"
++
+ /**
+  * \file agc.h
+  */
+@@ -43,6 +45,9 @@ static constexpr utils::Duration kMaxShutterSpeed = 60ms;
+ /* Number of frames to wait before calculating stats on minimum exposure */
+ static constexpr uint32_t kNumStartupFrames = 10;
+ 
++/* Target value to reach for the top 2% of the histogram */
++static constexpr double kEvGainTarget = 0.5;
++
+ /*
+  * Relative luminance target.
+  *
+@@ -51,10 +56,10 @@ static constexpr uint32_t kNumStartupFrames = 10;
+  *
+  * \todo Why is the value different between IPU3 and RkISP1 ?
+  */
+-static constexpr double kRelativeLuminanceTarget = 0.4;
++static constexpr double kRelativeLuminanceTarget = 0.16;
+ 
+ Agc::Agc()
+-	: frameCount_(0), numCells_(0), filteredExposure_(0s)
++	: frameCount_(0), numCells_(0), numHistBins_(0), filteredExposure_(0s)
+ {
+ }
+ 
+@@ -65,8 +70,7 @@ Agc::Agc()
+  *
+  * \return 0
+  */
+-int Agc::configure(IPAContext &context,
+-		   [[maybe_unused]] const IPACameraSensorInfo &configInfo)
++int Agc::configure(IPAContext &context, const IPACameraSensorInfo &configInfo)
+ {
+ 	/* Configure the default exposure and gain. */
+ 	context.frameContext.agc.gain = std::max(context.configuration.agc.minAnalogueGain, kMinAnalogueGain);
+@@ -77,10 +81,19 @@ int Agc::configure(IPAContext &context,
+ 	 * - versions < V12 have RKISP1_CIF_ISP_AE_MEAN_MAX_V10 entries,
+ 	 * - versions >= V12 have RKISP1_CIF_ISP_AE_MEAN_MAX_V12 entries.
+ 	 */
+-	if (context.configuration.hw.revision < RKISP1_V12)
++	if (context.configuration.hw.revision < RKISP1_V12) {
+ 		numCells_ = RKISP1_CIF_ISP_AE_MEAN_MAX_V10;
+-	else
++		numHistBins_ = RKISP1_CIF_ISP_HIST_BIN_N_MAX_V10;
++	} else {
+ 		numCells_ = RKISP1_CIF_ISP_AE_MEAN_MAX_V12;
++		numHistBins_ = RKISP1_CIF_ISP_HIST_BIN_N_MAX_V12;
++	}
++
++	/* Define the measurement window for AGC. */
++	context.configuration.agc.measureWindow.h_offs = configInfo.outputSize.width / 8;
++	context.configuration.agc.measureWindow.v_offs = configInfo.outputSize.height / 8;
++	context.configuration.agc.measureWindow.h_size = 3 * configInfo.outputSize.width / 4;
++	context.configuration.agc.measureWindow.v_size = 3 * configInfo.outputSize.height / 4;
+ 
+ 	return 0;
+ }
+@@ -125,7 +138,7 @@ utils::Duration Agc::filterExposure(utils::Duration exposureValue)
+  * \param[inout] frameContext The shared IPA frame Context
+  * \param[in] yGain The gain calculated on the current brightness level
+  */
+-void Agc::computeExposure(IPAContext &context, double yGain)
++void Agc::computeExposure(IPAContext &context, double yGain, double iqMeanGain)
+ {
+ 	IPASessionConfiguration &configuration = context.configuration;
+ 	IPAFrameContext &frameContext = context.frameContext;
+@@ -134,6 +147,9 @@ void Agc::computeExposure(IPAContext &context, double yGain)
+ 	uint32_t exposure = frameContext.sensor.exposure;
+ 	double analogueGain = frameContext.sensor.gain;
+ 
++	/* Use the highest of the two gain estimates. */
++	double evGain = std::max(yGain, iqMeanGain);
++
+ 	utils::Duration minShutterSpeed = configuration.agc.minShutterSpeed;
+ 	utils::Duration maxShutterSpeed = std::min(configuration.agc.maxShutterSpeed,
+ 						   kMaxShutterSpeed);
+@@ -144,7 +160,7 @@ void Agc::computeExposure(IPAContext &context, double yGain)
+ 					  kMaxAnalogueGain);
+ 
+ 	/* Consider within 1% of the target as correctly exposed. */
+-	if (utils::abs_diff(yGain, 1.0) < 0.01)
++	if (utils::abs_diff(evGain, 1.0) < 0.01)
+ 		return;
+ 
+ 	/* extracted from Rpi::Agc::computeTargetExposure. */
+@@ -161,13 +177,13 @@ void Agc::computeExposure(IPAContext &context, double yGain)
+ 	LOG(RkISP1Agc, Debug) << "Actual total exposure " << currentShutter * analogueGain
+ 			      << " Shutter speed " << currentShutter
+ 			      << " Gain " << analogueGain
+-			      << " Needed ev gain " << yGain;
++			      << " Needed ev gain " << evGain;
+ 
+ 	/*
+ 	 * Calculate the current exposure value for the scene as the latest
+ 	 * exposure value applied multiplied by the new estimated gain.
+ 	 */
+-	utils::Duration exposureValue = effectiveExposureValue * yGain;
++	utils::Duration exposureValue = effectiveExposureValue * evGain;
+ 
+ 	/* Clamp the exposure value to the min and max authorized. */
+ 	utils::Duration maxTotalExposure = maxShutterSpeed * maxAnalogueGain;
+@@ -238,6 +254,23 @@ double Agc::estimateLuminance(const rkisp1_cif_isp_ae_stat *ae,
+ 	return ySum / numCells_ / 255;
+ }
+ 
++/**
++ * \brief Estimate the mean value of the top 2% of the histogram
++ * \param[in] hist The histogram statistics computed by the ImgU
++ * \return The mean value of the top 2% of the histogram
++ */
++double Agc::measureBrightness(const rkisp1_cif_isp_hist_stat *hist) const
++{
++	std::vector<uint32_t> measHist(numHistBins_);
++
++	/* Initialise the histogram array using the maximum available size */
++	for (unsigned int histBin = 0; histBin < numHistBins_; histBin++)
++		measHist.push_back(hist->hist_bins[histBin]);
++
++	/* Estimate the quantile mean of the top 2% of the histogram. */
++	return Histogram(Span<uint32_t>(measHist)).interQuantileMean(0.98, 1.0);
++}
++
+ /**
+  * \brief Process RkISP1 statistics, and run AGC operations
+  * \param[in] context The shared IPA context
+@@ -252,9 +285,13 @@ void Agc::process(IPAContext &context, const rkisp1_stat_buffer *stats)
+ 	ASSERT(stats->meas_type & RKISP1_CIF_ISP_STAT_AUTOEXP);
+ 
+ 	const rkisp1_cif_isp_ae_stat *ae = &params->ae;
++	const rkisp1_cif_isp_hist_stat *hist = &params->hist;
+ 
+ 	frameCount_ = context.frameContext.frameId;
+ 
++	double iqMean = measureBrightness(hist);
++	double iqMeanGain = kEvGainTarget * numHistBins_ / iqMean;
++
+ 	/*
+ 	 * Estimate the gain needed to achieve a relative luminance target. To
+ 	 * account for non-linearity caused by saturation, the value needs to be
+@@ -277,14 +314,38 @@ void Agc::process(IPAContext &context, const rkisp1_stat_buffer *stats)
+ 			break;
+ 	}
+ 
+-	computeExposure(context, yGain);
++	computeExposure(context, yGain, iqMeanGain);
+ }
+ 
+-void Agc::prepare([[maybe_unused]] IPAContext &context,
+-		  rkisp1_params_cfg *params)
++/**
++ * \copydoc libcamera::ipa::Algorithm::prepare
++ */
++void Agc::prepare(IPAContext &context, rkisp1_params_cfg *params)
+ {
++	/* Configure the measurement window. */
++	params->meas.aec_config.meas_window = context.configuration.agc.measureWindow;
++	/* Use a continuous methode for measure. */
++	params->meas.aec_config.autostop = RKISP1_CIF_ISP_EXP_CTRL_AUTOSTOP_0;
++	/* Estimate Y as (R + G + B) x (85/256). */
++	params->meas.aec_config.mode = RKISP1_CIF_ISP_EXP_MEASURING_MODE_1;
++	params->module_cfg_update |= RKISP1_CIF_ISP_MODULE_AEC;
+ 	params->module_ens |= RKISP1_CIF_ISP_MODULE_AEC;
+ 	params->module_en_update |= RKISP1_CIF_ISP_MODULE_AEC;
++
++	/* Configure histogram. */
++	params->meas.hst_config.meas_window = context.configuration.agc.measureWindow;
++	/* Produce the luminance histogram. */
++	params->meas.hst_config.mode = RKISP1_CIF_ISP_HISTOGRAM_MODE_Y_HISTOGRAM;
++	/* Set an average weighted histogram. */
++	for (unsigned int histBin = 0; histBin < numHistBins_; histBin++)
++		params->meas.hst_config.hist_weight[histBin] = 1;
++	/* Step size can't be less than 3. */
++	params->meas.hst_config.histogram_predivider = 4;
++	/* Update the configuration for histogram. */
++	params->module_cfg_update |= RKISP1_CIF_ISP_MODULE_HST;
++	/* Enable the histogram measure unit. */
++	params->module_ens |= RKISP1_CIF_ISP_MODULE_HST;
++	params->module_en_update |= RKISP1_CIF_ISP_MODULE_HST;
+ }
+ 
+ } /* namespace ipa::rkisp1::algorithms */
+diff --git a/src/ipa/rkisp1/algorithms/agc.h b/src/ipa/rkisp1/algorithms/agc.h
+index 942c9d7a..872776d0 100644
+--- a/src/ipa/rkisp1/algorithms/agc.h
++++ b/src/ipa/rkisp1/algorithms/agc.h
+@@ -32,13 +32,15 @@ public:
+ 	void process(IPAContext &context, const rkisp1_stat_buffer *stats) override;
+ 
+ private:
+-	void computeExposure(IPAContext &Context, double yGain);
++	void computeExposure(IPAContext &Context, double yGain, double iqMeanGain);
+ 	utils::Duration filterExposure(utils::Duration exposureValue);
+ 	double estimateLuminance(const rkisp1_cif_isp_ae_stat *ae, double gain);
++	double measureBrightness(const rkisp1_cif_isp_hist_stat *hist) const;
+ 
+ 	uint64_t frameCount_;
+ 
+ 	uint32_t numCells_;
++	uint32_t numHistBins_;
+ 
+ 	utils::Duration filteredExposure_;
+ };
+-- 
+2.25.1
+


### PR DESCRIPTION
Bumps SRCREV of libcamera for hardnott and updates meson build system options. This also enables libcamera pipelines for rpi, rockchip and uvcvideo. We also add rkisp1 ipa patches from the libcamera mailing list that increase the image quality of the images captured.

Tested on RockPi4b with Sony imx219.

Example image without 3a https://people.linaro.org/~peter.griffin/rkisp1captures/test_no3a.png
Example image with these patches applied https://people.linaro.org/~peter.griffin/rkisp1captures/test_3a.png