### PR TITLE
op-tee updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LEDGE Reference Platform
 
-meta-ledge is the layer that implements the LEDGE reference platform (LEFGE RP).
+meta-ledge is the layer that implements the LEDGE reference platform (LEDGE RP).
 LEDGE RP is designed to be a secure minimal distro that can be built upon. It
 aims to be 'secure by default' saving vendors from having to do the same potentially
 error prone integration themselves.

--- a/meta-ledge-sw/recipes-security/optee/optee-client.bbappend
+++ b/meta-ledge-sw/recipes-security/optee/optee-client.bbappend
@@ -6,6 +6,10 @@ SRCREV_ledgecommon = "06e1b32f6a7028e039c625b07cfc25fda0c17d53"
 
 DEPENDS_append_ledgecommon += "python3-pycryptodomex-native python3-pycrypto-native"
 
+EXTRA_OEMAKE = " \
+    RPMB_EMU=0 \
+"
+
 do_install() {
     oe_runmake install
 

--- a/meta-ledge-sw/recipes-security/optee/optee-client.bbappend
+++ b/meta-ledge-sw/recipes-security/optee/optee-client.bbappend
@@ -1,8 +1,8 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
-# 3.9
-PV="3.9.0+git${SRCPV}"
-SRCREV_ledgecommon = "e9e55969d76ddefcb5b398e592353e5c7f5df198"
+# 3.14
+PV="3.14.0+git${SRCPV}"
+SRCREV_ledgecommon = "06e1b32f6a7028e039c625b07cfc25fda0c17d53"
 
 DEPENDS_append_ledgecommon += "python3-pycryptodomex-native python3-pycrypto-native"
 

--- a/meta-ledge-sw/recipes-security/optee/optee-test_git.bbappend
+++ b/meta-ledge-sw/recipes-security/optee/optee-test_git.bbappend
@@ -1,9 +1,9 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
-# 3.9
+# 3.14
 SRC_URI = "git://github.com/OP-TEE/optee_test.git"
 
-PV="3.9.0+git${SRCPV}"
-SRCREV_ledgecommon = "f461e1d47fcc82eaa67508a3d796c11b7d26656e"
+PV="3.14.0+git${SRCPV}"
+SRCREV_ledgecommon = "f2eb88affbb7f028561b4fd5cbd049d5d704f741"
 
 DEPENDS_append_ledgecommon += "python3-pycryptodomex-native python3-pycrypto-native"
 


### PR DESCRIPTION
Align optee-test and optee-client with v3.14 release (which is what meta-trusted substrate builds for optee-os). Also disable RPMB_EMU as boards are using RPMB