### PR TITLE
Add bbappend for two recipes in meta-openembedded and meta-virtualization

### DIFF
--- a/meta-ledge-sw/recipes-containers/runc/runc-opencontainers_%.bbappend
+++ b/meta-ledge-sw/recipes-containers/runc/runc-opencontainers_%.bbappend
@@ -1,0 +1,4 @@
+SRC_URI = " \
+    git://github.com/opencontainers/runc;branch=main;protocol=https \
+    file://0001-Makefile-respect-GOBUILDFLAGS-for-runc-and-remove-re.patch \
+    "

--- a/meta-ledge-sw/recipes-extended/ostree/ostree_%.bbappend
+++ b/meta-ledge-sw/recipes-extended/ostree/ostree_%.bbappend
@@ -1,0 +1,4 @@
+SRC_URI = " \
+    gitsm://github.com/ostreedev/ostree;branch=main;protocol=https \
+    file://run-ptest \
+"


### PR DESCRIPTION
The recipes:
- [meta-openembedded/]meta-oe/recipes-extended/ostree/ostree_2021.1.bb from
  https://github.com/openembedded/meta-openembedded @ 9ee0e08ba239 and
- [meta-virtualization/]recipes-containers/runc/runc-opencontainers_git.bb
  from http://git.yoctoproject.org/git/meta-virtualization @ 6c9b889224ce
cause do_fetch errors due to GitHub not accepting unauthenticated git
connections anymore and a branch name change. Fix this by adding bbappend
files to override the SRC_URI provided in the original recipes.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>