### PR TITLE
init.cryptfs: kill tee-supplicant on exit

### DIFF
--- a/meta-ledge-sw/recipes-ledge/images/files/init.cryptfs
+++ b/meta-ledge-sw/recipes-ledge/images/files/init.cryptfs
@@ -13,9 +13,18 @@
 ARG_MNT_TARGET=$1
 ARG_ROOT=$2
 
+function atexit {
+	# Do not leave tee-supplicant running. The rootfs init (systemd) will
+	# take care of starting it to its taste.
+	[ "$SUPP_PID" ] && kill $SUPP_PID
+}
+
+trap atexit EXIT
+
 /usr/sbin/rngd
 modprobe tpm_tis
 tee-supplicant &
+SUPP_PID=$!
 modprobe tpm_ftpm_tee
 
 


### PR DESCRIPTION
tee-supplicant should not be left running after init.cryptfs has run
because it will later be started as part of the rootfs boot sequence
(e.g., by systemd).

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>