### PR TITLE
bump optee to v3.16

### DIFF
--- a/meta-ledge-sw/recipes-security/optee/optee-client/0001-libckteec-add-support-for-ECDH-derive.patch
+++ b/meta-ledge-sw/recipes-security/optee/optee-client/0001-libckteec-add-support-for-ECDH-derive.patch
@@ -1,0 +1,118 @@
+From 8b3f7fe3401f0853b4af32aed2c1b436f3a36377 Mon Sep 17 00:00:00 2001
+From: Jorge Ramirez-Ortiz <jorge@foundries.io>
+Date: Thu, 2 Dec 2021 23:06:01 +0100
+Subject: [PATCH 1/6] libckteec: add support for ECDH derive
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This commit adds support for Elliptic curve Diffie-Hellman key
+derivation, a mechanism where each party contributes one key pair all
+using the same EC domain parameters.
+
+The mechanism derives a secret value and truncates the result.
+
+Tested with pkcs11_tool -m ECDH1-DERIVE
+
+Signed-off-by: Jorge Ramirez-Ortiz <jorge@foundries.io>
+Reviewed-by: Etienne Carriere <etienne.carriere@linaro.org>
+Reviewed-by: Vesa Jääskeläinen <vesa.jaaskelainen@vaisala.com>
+---
+ libckteec/include/pkcs11.h   | 21 ++++++++++++++++++
+ libckteec/src/serialize_ck.c | 41 ++++++++++++++++++++++++++++++++++++
+ 2 files changed, 62 insertions(+)
+
+diff --git a/libckteec/include/pkcs11.h b/libckteec/include/pkcs11.h
+index f658db6..948738a 100644
+--- a/libckteec/include/pkcs11.h
++++ b/libckteec/include/pkcs11.h
+@@ -438,6 +438,27 @@ typedef CK_ULONG CK_RSA_PKCS_OAEP_SOURCE_TYPE;
+ typedef CK_ULONG CK_MAC_GENERAL_PARAMS;
+ typedef CK_MAC_GENERAL_PARAMS *CK_MAC_GENERAL_PARAMS_PTR;
+ 
++/*
++ * CK_EC_KDF_TYPE is used to indicate the Key Derivation Function (KDF) applied
++ * to derive keying data from a shared secret.
++ */
++typedef CK_ULONG CK_EC_KDF_TYPE;
++
++/*
++ * Elliptic curve Diffie-Hellman key derivation
++ * Elliptic curve Diffie-Hellman cofactor key derivation parameters
++ */
++typedef struct CK_ECDH1_DERIVE_PARAMS CK_ECDH1_DERIVE_PARAMS;
++typedef struct CK_ECDH1_DERIVE_PARAMS *CK_ECDH1_DERIVE_PARAMS_PTR;
++
++struct CK_ECDH1_DERIVE_PARAMS {
++	CK_EC_KDF_TYPE		kdf;
++	CK_ULONG		ulSharedDataLen;
++	CK_BYTE_PTR		pSharedData;
++	CK_ULONG		ulPublicDataLen;
++	CK_BYTE_PTR		pPublicData;
++};
++
+ /* AES CBC encryption parameters */
+ typedef struct CK_AES_CBC_ENCRYPT_DATA_PARAMS CK_AES_CBC_ENCRYPT_DATA_PARAMS;
+ typedef struct CK_AES_CBC_ENCRYPT_DATA_PARAMS
+diff --git a/libckteec/src/serialize_ck.c b/libckteec/src/serialize_ck.c
+index edb8d09..07382a5 100644
+--- a/libckteec/src/serialize_ck.c
++++ b/libckteec/src/serialize_ck.c
+@@ -451,6 +451,43 @@ static CK_RV serialize_mecha_key_deriv_str(struct serializer *obj,
+ 	return serialize_buffer(obj, param->pData, param->ulLen);
+ }
+ 
++static CK_RV serialize_mecha_ecdh1_derive_param(struct serializer *obj,
++						CK_MECHANISM_PTR mecha)
++{
++	CK_ECDH1_DERIVE_PARAMS *params = mecha->pParameter;
++	CK_RV rv = CKR_GENERAL_ERROR;
++	size_t params_size = 3 * sizeof(uint32_t) + params->ulSharedDataLen +
++			     params->ulPublicDataLen;
++
++	rv = serialize_32b(obj, obj->type);
++	if (rv)
++		return rv;
++
++	rv = serialize_32b(obj, params_size);
++	if (rv)
++		return rv;
++
++	rv = serialize_32b(obj, params->kdf);
++	if (rv)
++		return rv;
++
++	rv = serialize_32b(obj, params->ulSharedDataLen);
++	if (rv)
++		return rv;
++
++	rv = serialize_buffer(obj, params->pSharedData,
++			      params->ulSharedDataLen);
++	if (rv)
++		return rv;
++
++	rv = serialize_32b(obj, params->ulPublicDataLen);
++	if (rv)
++		return rv;
++
++	return serialize_buffer(obj, params->pPublicData,
++				params->ulPublicDataLen);
++}
++
+ static CK_RV serialize_mecha_aes_cbc_encrypt_data(struct serializer *obj,
+ 						  CK_MECHANISM_PTR mecha)
+ {
+@@ -650,6 +687,10 @@ CK_RV serialize_ck_mecha_params(struct serializer *obj,
+ 	case CKM_AES_CBC_ENCRYPT_DATA:
+ 		return serialize_mecha_aes_cbc_encrypt_data(obj, &mecha);
+ 
++	case CKM_ECDH1_DERIVE:
++	case CKM_ECDH1_COFACTOR_DERIVE:
++		return serialize_mecha_ecdh1_derive_param(obj, &mecha);
++
+ 	case CKM_RSA_PKCS_PSS:
+ 	case CKM_SHA1_RSA_PKCS_PSS:
+ 	case CKM_SHA256_RSA_PKCS_PSS:
+-- 
+2.25.1
+

--- a/meta-ledge-sw/recipes-security/optee/optee-client/0002-tee-supplicant-introduce-struct-tee_supplicant_param.patch
+++ b/meta-ledge-sw/recipes-security/optee/optee-client/0002-tee-supplicant-introduce-struct-tee_supplicant_param.patch
@@ -1,0 +1,112 @@
+From 876b1ae719e12890ddd96e85cd4e9862dab46448 Mon Sep 17 00:00:00 2001
+From: Ondrej Kubik <ondrej.kubik@canonical.com>
+Date: Thu, 3 Feb 2022 21:31:04 +0000
+Subject: [PATCH 2/6] tee-supplicant: introduce struct tee_supplicant_params
+ for global config
+
+Signed-off-by: Ondrej Kubik <ondrej.kubik@canonical.com>
+Reviewed-by: Jerome Forissier <jerome@forissier.org>
+---
+ tee-supplicant/src/plugin.c         | 5 +++--
+ tee-supplicant/src/tee_supp_fs.c    | 5 +++--
+ tee-supplicant/src/tee_supplicant.c | 9 ++++++---
+ tee-supplicant/src/tee_supplicant.h | 9 +++++++++
+ 4 files changed, 21 insertions(+), 7 deletions(-)
+
+diff --git a/tee-supplicant/src/plugin.c b/tee-supplicant/src/plugin.c
+index 2769baa..c3cbe16 100644
+--- a/tee-supplicant/src/plugin.c
++++ b/tee-supplicant/src/plugin.c
+@@ -113,9 +113,10 @@ TEEC_Result plugin_load_all(void)
+ 	TEEC_Result teec_res = TEEC_SUCCESS;
+ 	struct dirent *entry = NULL;
+ 
+-	dir = opendir(TEE_PLUGIN_LOAD_PATH);
++	dir = opendir(supplicant_params.plugin_load_path);
++
+ 	if (!dir) {
+-		IMSG("could not open directory %s", TEE_PLUGIN_LOAD_PATH);
++		IMSG("could not open directory %s", supplicant_params.plugin_load_path);
+ 
+ 		/* don't generate error if there is no the dir */
+ 		return TEEC_SUCCESS;
+diff --git a/tee-supplicant/src/tee_supp_fs.c b/tee-supplicant/src/tee_supp_fs.c
+index 5580ba9..e6a587a 100644
+--- a/tee-supplicant/src/tee_supp_fs.c
++++ b/tee-supplicant/src/tee_supp_fs.c
+@@ -121,7 +121,8 @@ static int tee_supp_fs_init(void)
+ 	size_t n = 0;
+ 	mode_t mode = 0700;
+ 
+-	n = snprintf(tee_fs_root, sizeof(tee_fs_root), "%s/", TEE_FS_PARENT_PATH);
++	n = snprintf(tee_fs_root, sizeof(tee_fs_root), "%s/", supplicant_params.fs_parent_path);
++
+ 	if (n >= sizeof(tee_fs_root))
+ 		return -1;
+ 
+@@ -613,7 +614,7 @@ TEEC_Result tee_supp_fs_process(size_t num_params,
+ 	if (strlen(tee_fs_root) == 0) {
+ 		if (tee_supp_fs_init() != 0) {
+ 			EMSG("error tee_supp_fs_init: failed to create %s/",
+-				TEE_FS_PARENT_PATH);
++				tee_fs_root);
+ 			memset(tee_fs_root, 0, sizeof(tee_fs_root));
+ 			return TEEC_ERROR_STORAGE_NOT_AVAILABLE;
+ 		}
+diff --git a/tee-supplicant/src/tee_supplicant.c b/tee-supplicant/src/tee_supplicant.c
+index 1da3995..d083b3e 100644
+--- a/tee-supplicant/src/tee_supplicant.c
++++ b/tee-supplicant/src/tee_supplicant.c
+@@ -98,7 +98,11 @@ struct param_value {
+ static pthread_mutex_t shm_mutex = PTHREAD_MUTEX_INITIALIZER;
+ static struct tee_shm *shm_head;
+ 
+-static const char *ta_dir;
++struct tee_supplicant_params supplicant_params = {
++	.ta_dir = "optee_armtz",
++	.plugin_load_path = TEE_PLUGIN_LOAD_PATH,
++	.fs_parent_path  = TEE_FS_PARENT_PATH,
++};
+ 
+ static void *thread_main(void *a);
+ 
+@@ -290,7 +294,7 @@ static uint32_t load_ta(size_t num_params, struct tee_ioctl_param *params)
+ 	uuid_from_octets(&uuid, (void *)val_cmd);
+ 
+ 	size = shm_ta.size;
+-	ta_found = TEECI_LoadSecureModule(ta_dir, &uuid, shm_ta.buffer, &size);
++	ta_found = TEECI_LoadSecureModule(supplicant_params.ta_dir, &uuid, shm_ta.buffer, &size);
+ 	if (ta_found != TA_BINARY_FOUND) {
+ 		EMSG("  TA not found");
+ 		return TEEC_ERROR_ITEM_NOT_FOUND;
+@@ -453,7 +457,6 @@ static int open_dev(const char *devname, uint32_t *gen_caps)
+ 	if (vers.impl_id != TEE_IMPL_ID_OPTEE)
+ 		goto err;
+ 
+-	ta_dir = "optee_armtz";
+ 	if (gen_caps)
+ 		*gen_caps = vers.gen_caps;
+ 
+diff --git a/tee-supplicant/src/tee_supplicant.h b/tee-supplicant/src/tee_supplicant.h
+index 11f2b80..b72faec 100644
+--- a/tee-supplicant/src/tee_supplicant.h
++++ b/tee-supplicant/src/tee_supplicant.h
+@@ -38,6 +38,15 @@
+ 
+ struct tee_ioctl_param;
+ 
++/* Global tee-supplicant parameters */
++struct tee_supplicant_params {
++    const char *ta_dir;
++    const char *plugin_load_path;
++    const char *fs_parent_path;
++};
++
++extern struct tee_supplicant_params supplicant_params;
++
+ bool tee_supp_param_is_memref(struct tee_ioctl_param *param);
+ bool tee_supp_param_is_value(struct tee_ioctl_param *param);
+ void *tee_supp_param_to_va(struct tee_ioctl_param *param);
+-- 
+2.25.1
+

--- a/meta-ledge-sw/recipes-security/optee/optee-client/0003-tee-supplicant-refactor-argument-parsing-in-main.patch
+++ b/meta-ledge-sw/recipes-security/optee/optee-client/0003-tee-supplicant-refactor-argument-parsing-in-main.patch
@@ -1,0 +1,114 @@
+From edf30722ab94317c29c0d49ef8d946239cb7d600 Mon Sep 17 00:00:00 2001
+From: Ondrej Kubik <ondrej.kubik@canonical.com>
+Date: Thu, 3 Feb 2022 21:35:57 +0000
+Subject: [PATCH 3/6] tee-supplicant: refactor argument parsing in main()
+
+Signed-off-by: Ondrej Kubik <ondrej.kubik@canonical.com>
+Reviewed-by: Jerome Forissier <jerome@forissier.org>
+---
+ tee-supplicant/src/tee_supplicant.c | 67 +++++++++++++++++++++++------
+ 1 file changed, 54 insertions(+), 13 deletions(-)
+
+diff --git a/tee-supplicant/src/tee_supplicant.c b/tee-supplicant/src/tee_supplicant.c
+index d083b3e..033297c 100644
+--- a/tee-supplicant/src/tee_supplicant.c
++++ b/tee-supplicant/src/tee_supplicant.c
+@@ -31,6 +31,7 @@
+ #include <dirent.h>
+ #include <errno.h>
+ #include <fcntl.h>
++#include <getopt.h>
+ #include <inttypes.h>
+ #include <prof.h>
+ #include <plugin.h>
+@@ -484,9 +485,16 @@ static int get_dev_fd(uint32_t *gen_caps)
+ 
+ static int usage(int status)
+ {
+-	fprintf(stderr, "Usage: tee-supplicant [-d] [<device-name>]\n");
+-	fprintf(stderr, "       -d: run as a daemon (fork after successful "
++	fprintf(stderr, "Usage: tee-supplicant [options] [<device-name>]\n");
++	fprintf(stderr, "\t-h, --help: this help\n");
++	fprintf(stderr, "\t-d, --daemonize: run as a daemon (fork after successful "
+ 			"initialization)\n");
++	fprintf(stderr, "\t-f, --fs-parent-path: secure fs parent path [%s]\n",
++			supplicant_params.fs_parent_path);
++	fprintf(stderr, "\t-t, --ta-dir: TAs dirname under %s [%s]\n", TEEC_LOAD_PATH,
++			supplicant_params.ta_dir);
++	fprintf(stderr, "\t-p, --plugin-path: plugin load path [%s]\n",
++			supplicant_params.plugin_load_path);
+ 	return status;
+ }
+ 
+@@ -688,7 +696,8 @@ int main(int argc, char *argv[])
+ 	bool daemonize = false;
+ 	char *dev = NULL;
+ 	int e = 0;
+-	int i = 0;
++	int long_index = 0;
++	int opt = 0;
+ 
+ 	e = pthread_mutex_init(&arg.mutex, NULL);
+ 	if (e) {
+@@ -697,16 +706,48 @@ int main(int argc, char *argv[])
+ 		exit(EXIT_FAILURE);
+ 	}
+ 
+-	if (argc > 3)
+-		return usage(EXIT_FAILURE);
+-
+-	for (i = 1; i < argc; i++) {
+-		if (!strcmp(argv[i], "-d"))
+-			daemonize = true;
+-		else if (!strcmp(argv[i], "-h"))
+-			return usage(EXIT_SUCCESS);
+-		else
+-			dev = argv[i];
++	static struct option long_options[] = {
++		/* long name      | has argument  | flag | short value */
++		{ "help",            no_argument,       0, 'h' },
++		{ "daemonize",       no_argument,       0, 'd' },
++		{ "fs-parent-path",  required_argument, 0, 'f' },
++		{ "ta-dir",          required_argument, 0, 't' },
++		{ "plugin-path",     required_argument, 0, 'p' },
++		{ 0, 0, 0, 0 }
++	};
++
++	while ((opt = getopt_long(argc, argv, "hdf:t:p:",
++				long_options, &long_index )) != -1) {
++		switch (opt) {
++			case 'h' :
++				return usage(EXIT_SUCCESS);
++				break;
++			case 'd':
++				daemonize = true;
++				break;
++			case 'f':
++				supplicant_params.fs_parent_path = optarg;
++				break;
++			case 't':
++				supplicant_params.ta_dir = optarg;
++				break;
++			case 'p':
++				supplicant_params.plugin_load_path = optarg;
++				break;
++			default:
++				return usage(EXIT_FAILURE);
++		}
++	}
++	/* check for non option argument, which is device name */
++	if (argv[optind]) {
++		fprintf(stderr, "Using device %s.\n", argv[optind]);
++		dev = argv[optind];
++		/* check that we do not have too many arguments */
++		if (argv[optind + 1]) {
++			fprintf(stderr, "Too many arguments passed: extra argument: %s.\n",
++					argv[optind+1]);
++			return usage(EXIT_FAILURE);
++		}
+ 	}
+ 
+ 	if (daemonize && daemon(0, 0) < 0) {
+-- 
+2.25.1
+

--- a/meta-ledge-sw/recipes-security/optee/optee-client/0004-tee-supplicant-rpmb-introduce-readn-wrapper-to-the-r.patch
+++ b/meta-ledge-sw/recipes-security/optee/optee-client/0004-tee-supplicant-rpmb-introduce-readn-wrapper-to-the-r.patch
@@ -1,0 +1,78 @@
+From 179d212d6aed75267e580e00b924f9e50cf4a609 Mon Sep 17 00:00:00 2001
+From: Jerome Forissier <jerome.forissier@linaro.org>
+Date: Fri, 18 Mar 2022 10:55:43 +0100
+Subject: [PATCH 4/6] tee-supplicant: rpmb: introduce readn() wrapper to the
+ read() syscall
+
+read_cid() obtains the ID of the eMMC device by reading from sysfs with
+the read() function. Two bytes are read at a time but short reads (i.e.,
+when only one byte is returned) and EINTR are not handled. Although I
+*think* these situation cannot happen with sysfs, I was unable to find
+any guarantee that it is the case. Therefore, introduce a readn()
+function which does exactly that.
+
+Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>
+Reviewed-by: Etienne Carriere <etienne.carriere@linaro.org>
+Acked-by: Jens Wiklander <jens.wiklander@linaro.org>
+---
+ tee-supplicant/src/rpmb.c | 37 ++++++++++++++++++++++++++++++++++---
+ 1 file changed, 34 insertions(+), 3 deletions(-)
+
+diff --git a/tee-supplicant/src/rpmb.c b/tee-supplicant/src/rpmb.c
+index 7418e23..a95c60b 100644
+--- a/tee-supplicant/src/rpmb.c
++++ b/tee-supplicant/src/rpmb.c
+@@ -201,6 +201,35 @@ static void close_mmc_fd(int fd)
+ 	close(fd);
+ }
+ 
++/*
++ * Read @n bytes from @fd, takes care of short reads and EINTR.
++ * Adapted from “Advanced Programming In the UNIX Environment” by W. Richard
++ * Stevens and Stephen A. Rago, 2013, 3rd Edition, Addison-Wesley
++ * (EINTR handling was added)
++ */
++static ssize_t readn(int fd, void *ptr, size_t n)
++{
++	size_t nleft = n;
++	ssize_t nread = 0;
++	uint8_t *p = ptr;
++
++	while (nleft > 0) {
++		if ((nread = read(fd, p, nleft)) < 0) {
++			if (errno == EINTR)
++				continue;
++			if (nleft == n)
++				return -1; /* error, nothing read, return -1 */
++			else
++				break; /* error, return amount read so far */
++		} else if (nread == 0) {
++			break; /* EOF */
++		}
++		nleft -= nread;
++		p += nread;
++	}
++	return n - nleft; /* return >= 0 */
++}
++
+ /* Device Identification (CID) register is 16 bytes. It is read from sysfs. */
+ static uint32_t read_cid(uint16_t dev_id, uint8_t *cid)
+ {
+@@ -220,9 +249,11 @@ static uint32_t read_cid(uint16_t dev_id, uint8_t *cid)
+ 	}
+ 
+ 	for (i = 0; i < 16; i++) {
+-		st = read(fd, hex, 2);
+-		if (st < 0) {
+-			EMSG("Read CID error (%s)", strerror(errno));
++		st = readn(fd, hex, 2);
++		if (st != 2) {
++			EMSG("Read CID error");
++			if (errno)
++				EMSG("%s", strerror(errno));
+ 			res = TEEC_ERROR_NO_DATA;
+ 			goto err;
+ 		}
+-- 
+2.25.1
+

--- a/meta-ledge-sw/recipes-security/optee/optee-client/0005-tee-supplicant-rpmb-read-CID-in-one-go.patch
+++ b/meta-ledge-sw/recipes-security/optee/optee-client/0005-tee-supplicant-rpmb-read-CID-in-one-go.patch
@@ -1,0 +1,132 @@
+From 319ed5ef6f9cfb1f3457d643315172231ccea861 Mon Sep 17 00:00:00 2001
+From: Jerome Forissier <jerome.forissier@linaro.org>
+Date: Fri, 18 Mar 2022 11:14:19 +0100
+Subject: [PATCH 5/6] tee-supplicant: rpmb: read CID in one go
+
+Introduce read_cid_str() to read the whole eMMC CID from sysfs in one
+go rather than doing it two bytes at a time. This function will come
+in handy in the next commit.
+
+Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>
+Acked-by: Jens Wiklander <jens.wiklander@linaro.org>
+---
+ tee-supplicant/src/rpmb.c | 81 +++++++++++++++++++++++++++++----------
+ 1 file changed, 60 insertions(+), 21 deletions(-)
+
+diff --git a/tee-supplicant/src/rpmb.c b/tee-supplicant/src/rpmb.c
+index a95c60b..6bd97ca 100644
+--- a/tee-supplicant/src/rpmb.c
++++ b/tee-supplicant/src/rpmb.c
+@@ -66,7 +66,8 @@ struct rpmb_req {
+ 
+ /* Response to device info request */
+ struct rpmb_dev_info {
+-	uint8_t cid[16];
++#define RPMB_CID_SZ 16
++	uint8_t cid[RPMB_CID_SZ];
+ 	uint8_t rpmb_size_mult;	/* EXT CSD-slice 168: RPMB Size */
+ 	uint8_t rel_wr_sec_c;	/* EXT CSD-slice 222: Reliable Write Sector */
+ 				/*                    Count */
+@@ -230,41 +231,79 @@ static ssize_t readn(int fd, void *ptr, size_t n)
+ 	return n - nleft; /* return >= 0 */
+ }
+ 
+-/* Device Identification (CID) register is 16 bytes. It is read from sysfs. */
+-static uint32_t read_cid(uint16_t dev_id, uint8_t *cid)
++/* Size of CID printed in hexadecimal */
++#define CID_STR_SZ (2 * RPMB_CID_SZ)
++
++static TEEC_Result read_cid_str(uint16_t dev_id, char cid[CID_STR_SZ + 1])
+ {
+ 	TEEC_Result res = TEEC_ERROR_GENERIC;
+ 	char path[48] = { 0 };
+-	char hex[3] = { 0 };
+-	int st = 0;
+ 	int fd = 0;
+-	int i = 0;
++	int st = 0;
+ 
+ 	snprintf(path, sizeof(path),
+ 		 "/sys/class/mmc_host/mmc%u/mmc%u:0001/cid", dev_id, dev_id);
+ 	fd = open(path, O_RDONLY);
+-	if (fd < 0) {
+-		EMSG("Could not open %s (%s)", path, strerror(errno));
++	if (fd < 0)
+ 		return TEEC_ERROR_ITEM_NOT_FOUND;
+-	}
+-
+-	for (i = 0; i < 16; i++) {
+-		st = readn(fd, hex, 2);
+-		if (st != 2) {
+-			EMSG("Read CID error");
+-			if (errno)
+-				EMSG("%s", strerror(errno));
+-			res = TEEC_ERROR_NO_DATA;
+-			goto err;
+-		}
+-		cid[i] = (uint8_t)strtol(hex, NULL, 16);
++	st = readn(fd, cid, CID_STR_SZ);
++	if (st != CID_STR_SZ) {
++		EMSG("Read CID error");
++		if (errno)
++			EMSG("%s", strerror(errno));
++		res = TEEC_ERROR_NO_DATA;
++		goto out;
+ 	}
+ 	res = TEEC_SUCCESS;
+-err:
++out:
+ 	close(fd);
+ 	return res;
+ }
+ 
++static int hexchar2int(char c)
++{
++	if (c >= '0' && c <= '9')
++		return c - '0';
++	if (c >= 'a' && c <= 'f')
++		return c - 'a' + 10;
++	if (c >= 'A' && c <= 'F')
++		return c - 'A' + 10;
++	return -1;
++}
++
++static int hexbyte2int(char *hex)
++{
++	int v1 = hexchar2int(hex[0]);
++	int v2 = hexchar2int(hex[1]);
++
++	if (v1 < 0 || v2 < 0)
++		return -1;
++	return 16 * v1 + v2;
++}
++
++/* Device Identification (CID) register is 16 bytes. It is read from sysfs. */
++static TEEC_Result read_cid(uint16_t dev_id, uint8_t *cid)
++{
++	TEEC_Result res = TEEC_ERROR_GENERIC;
++	char cid_str[CID_STR_SZ + 1] = { 0 };
++	int i = 0;
++	int v = 0;
++
++	res = read_cid_str(dev_id, cid_str);
++	if (res)
++		return res;
++
++	for (i = 0; i < RPMB_CID_SZ; i++) {
++		v = hexbyte2int(cid_str + 2 * i);
++		if (v < 0) {
++			EMSG("Invalid CID string: %s", cid_str);
++			return TEEC_ERROR_NO_DATA;
++		}
++		cid[i] = v;
++	}
++	return TEEC_SUCCESS;
++}
++
+ #else /* RPMB_EMU */
+ 
+ #define IOCTL(fd, request, ...) ioctl_emu((fd), (request), ##__VA_ARGS__)
+-- 
+2.25.1
+

--- a/meta-ledge-sw/recipes-security/optee/optee-client/0006-tee-supplicant-add-rpmb-cid-command-line-option.patch
+++ b/meta-ledge-sw/recipes-security/optee/optee-client/0006-tee-supplicant-add-rpmb-cid-command-line-option.patch
@@ -1,0 +1,223 @@
+From f75c5f30b4eb773dfa8fa95a3bd878631d8318da Mon Sep 17 00:00:00 2001
+From: Jerome Forissier <jerome.forissier@linaro.org>
+Date: Wed, 16 Mar 2022 19:33:26 +0100
+Subject: [PATCH 6/6] tee-supplicant: add --rpmb-cid command line option
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+In OP-TEE OS, the RPMB device used for secure storage is selected at
+compile time via an integer identifier (CFG_RPMB_FS_DEV_ID). As
+mentioned in [1], this ID is assigned by the Linux kernel and is used
+when tee-supplicant opens the device on behalf of OP-TEE. There are a
+couple of issues with that:
+
+1. U-Boot and Linux may assign a different number to the same RPMB
+device. Therefore, the TEE supplicant components in U-Boot and Linux
+cannot both trust the ID given by OP-TEE.
+
+2. If a system has several RPMB devices, and even if we ignore removable
+ones, there is no guarantee that the devices will always be enumerated
+in the same order by the kernel on boot. This results in different
+device numbers. I observed this behavior on a Hikey620 board with an
+external eMMC module plugged into the micro SD slot. Sometimes the
+on-board RPMB (which I don’t use for testing) is /dev/mmcblk0rpmb and
+the external one is /dev/mmcblk1rpmb; sometimes it is the other way
+around.
+
+In order to remove any ambiguity, introduce a new command line argument
+to tee-supplicant: --rpmb-cid <CID>. <CID> is the device identification
+register of the eMMC device that OP-TEE should use for RPMB. It is
+unique for every flash device. When --rpmb-cid is given, the device
+number given by OP-TEE is ignored and the specified device is used
+instead. <CID> can be found in sysfs, for example:
+
+ # Read the CID of MMC device 0. Its RPMB partition is /dev/mmcblk0rpmb.
+ $ cat /sys/class/mmc_host/mmc0/mmc0\:0001/cid
+ 11010030303847453000e0a18ceb13df
+ $
+
+Link: https://github.com/OP-TEE/optee_os/blob/3.16.0/mk/config.mk#L159-L162
+Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>
+Acked-by: Jens Wiklander <jens.wiklander@linaro.org>
+---
+ tee-supplicant/src/rpmb.c           | 80 +++++++++++++++++++++++++++--
+ tee-supplicant/src/tee_supplicant.c |  6 +++
+ tee-supplicant/src/tee_supplicant.h |  1 +
+ 3 files changed, 84 insertions(+), 3 deletions(-)
+
+diff --git a/tee-supplicant/src/rpmb.c b/tee-supplicant/src/rpmb.c
+index 6bd97ca..2c0da7b 100644
+--- a/tee-supplicant/src/rpmb.c
++++ b/tee-supplicant/src/rpmb.c
+@@ -25,6 +25,7 @@
+  * POSSIBILITY OF SUCH DAMAGE.
+  */
+ 
++#include <dirent.h>
+ #include <fcntl.h>
+ #include <linux/types.h>
+ #include <linux/mmc/ioctl.h>
+@@ -304,6 +305,70 @@ static TEEC_Result read_cid(uint16_t dev_id, uint8_t *cid)
+ 	return TEEC_SUCCESS;
+ }
+ 
++/*
++ * - If --rpmb-cid is given, find the eMMC RPMB device number with the specified
++ * CID, cache the number, copy it to @ndev_id and return true. If not found
++ * return false.
++ * - If --rpmb-cid is not given, copy @dev_id to @ndev_id and return true.
++ */
++static bool remap_rpmb_dev_id(uint16_t dev_id, uint16_t *ndev_id)
++{
++	TEEC_Result res = TEEC_ERROR_GENERIC;
++	static bool found = false;
++	static bool err = false;
++	static uint16_t id = 0;
++	char cid[33] = { 0 };
++	struct dirent *dent = NULL;
++	DIR *dir = NULL;
++	int num = 0;
++
++	if (err || found)
++		goto out;
++
++	if (!supplicant_params.rpmb_cid) {
++		id = dev_id;
++		found = true;
++		goto out;
++	}
++
++	dir = opendir("/sys/class/mmc_host");
++	if (!dir) {
++		EMSG("Could not open /sys/class/mmc_host (%s)",
++		     strerror(errno));
++		err = true;
++		goto out;
++	}
++
++	while ((dent = readdir(dir))) {
++		if (sscanf(dent->d_name, "%*[^0123456789]%d", &num) != 1)
++			continue;
++		if (num > UINT16_MAX) {
++			EMSG("Too many MMC devices");
++			err = true;
++			break;
++		}
++		id = (uint16_t)num;
++		res = read_cid_str(id, cid);
++		if (res)
++			continue;
++		if (strcmp(cid, supplicant_params.rpmb_cid))
++			continue;
++		fprintf(stderr, "RPMB device %s is at /dev/mmcblk%urpmb\n",
++			cid, id);
++		found = true;
++		break;
++	}
++
++	closedir(dir);
++
++	if (!found)
++		err = true;
++out:
++	if (found)
++		*ndev_id = id;
++	return found;
++}
++
+ #else /* RPMB_EMU */
+ 
+ #define IOCTL(fd, request, ...) ioctl_emu((fd), (request), ##__VA_ARGS__)
+@@ -692,6 +757,12 @@ static void close_mmc_fd(int fd)
+ 	(void)fd;
+ }
+ 
++static bool remap_rpmb_dev_id(uint16_t dev_id, uint16_t *ndev_id)
++{
++	*ndev_id = dev_id;
++	return true;
++}
++
+ #endif /* RPMB_EMU */
+ 
+ /*
+@@ -876,17 +947,21 @@ static uint32_t rpmb_process_request_unlocked(void *req, size_t req_size,
+ 	struct rpmb_req *sreq = req;
+ 	size_t req_nfrm = 0;
+ 	size_t rsp_nfrm = 0;
++	uint16_t dev_id = 0;
+ 	uint32_t res = 0;
+ 	int fd = 0;
+ 
+ 	if (req_size < sizeof(*sreq))
+ 		return TEEC_ERROR_BAD_PARAMETERS;
+ 
++	if (!remap_rpmb_dev_id(sreq->dev_id, &dev_id))
++		return TEEC_ERROR_ITEM_NOT_FOUND;
++
+ 	switch (sreq->cmd) {
+ 	case RPMB_CMD_DATA_REQ:
+ 		req_nfrm = (req_size - sizeof(struct rpmb_req)) / 512;
+ 		rsp_nfrm = rsp_size / 512;
+-		fd = mmc_rpmb_fd(sreq->dev_id);
++		fd = mmc_rpmb_fd(dev_id);
+ 		if (fd < 0)
+ 			return TEEC_ERROR_BAD_PARAMETERS;
+ 		res = rpmb_data_req(fd, RPMB_REQ_DATA(req), req_nfrm, rsp,
+@@ -899,8 +974,7 @@ static uint32_t rpmb_process_request_unlocked(void *req, size_t req_size,
+ 			EMSG("Invalid req/rsp size");
+ 			return TEEC_ERROR_BAD_PARAMETERS;
+ 		}
+-		res = rpmb_get_dev_info(sreq->dev_id,
+-					(struct rpmb_dev_info *)rsp);
++		res = rpmb_get_dev_info(dev_id, (struct rpmb_dev_info *)rsp);
+ 		break;
+ 
+ 	default:
+diff --git a/tee-supplicant/src/tee_supplicant.c b/tee-supplicant/src/tee_supplicant.c
+index 033297c..55924c4 100644
+--- a/tee-supplicant/src/tee_supplicant.c
++++ b/tee-supplicant/src/tee_supplicant.c
+@@ -495,6 +495,8 @@ static int usage(int status)
+ 			supplicant_params.ta_dir);
+ 	fprintf(stderr, "\t-p, --plugin-path: plugin load path [%s]\n",
+ 			supplicant_params.plugin_load_path);
++	fprintf(stderr, "\t-r, --rpmb-cid: RPMB device identification register "
++			"(CID) in hexadecimal\n");
+ 	return status;
+ }
+ 
+@@ -713,6 +715,7 @@ int main(int argc, char *argv[])
+ 		{ "fs-parent-path",  required_argument, 0, 'f' },
+ 		{ "ta-dir",          required_argument, 0, 't' },
+ 		{ "plugin-path",     required_argument, 0, 'p' },
++		{ "rpmb-cid",        required_argument, 0, 'r' },
+ 		{ 0, 0, 0, 0 }
+ 	};
+ 
+@@ -734,6 +737,9 @@ int main(int argc, char *argv[])
+ 			case 'p':
+ 				supplicant_params.plugin_load_path = optarg;
+ 				break;
++			case 'r':
++				supplicant_params.rpmb_cid = optarg;
++				break;
+ 			default:
+ 				return usage(EXIT_FAILURE);
+ 		}
+diff --git a/tee-supplicant/src/tee_supplicant.h b/tee-supplicant/src/tee_supplicant.h
+index b72faec..cf98ac8 100644
+--- a/tee-supplicant/src/tee_supplicant.h
++++ b/tee-supplicant/src/tee_supplicant.h
+@@ -43,6 +43,7 @@ struct tee_supplicant_params {
+     const char *ta_dir;
+     const char *plugin_load_path;
+     const char *fs_parent_path;
++    const char *rpmb_cid;
+ };
+ 
+ extern struct tee_supplicant_params supplicant_params;
+-- 
+2.25.1
+

--- a/meta-ledge-sw/recipes-security/optee/optee-client_%.bbappend
+++ b/meta-ledge-sw/recipes-security/optee/optee-client_%.bbappend
@@ -2,11 +2,20 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
 
 COMPATIBLE_MACHINE = "(ledge-qemuarm64|ledge-qemuarm)"
 
-# 3.14
-PV="3.14.0+git${SRCPV}"
-SRCREV_ledgecommon = "06e1b32f6a7028e039c625b07cfc25fda0c17d53"
+# 3.16
+PV="3.16.0+git${SRCPV}"
+SRCREV_ledgecommon = "06db73b3f3fdb8d23eceaedbc46c49c0b45fd1e2"
 
 DEPENDS_append_ledgecommon += "python3-pycryptodomex-native python3-pycrypto-native"
+
+SRC_URI_append = " \
+file://0001-libckteec-add-support-for-ECDH-derive.patch \
+	file://0002-tee-supplicant-introduce-struct-tee_supplicant_param.patch \
+	file://0003-tee-supplicant-refactor-argument-parsing-in-main.patch \
+	file://0004-tee-supplicant-rpmb-introduce-readn-wrapper-to-the-r.patch \
+	file://0005-tee-supplicant-rpmb-read-CID-in-one-go.patch \
+	file://0006-tee-supplicant-add-rpmb-cid-command-line-option.patch \
+	"
 
 EXTRA_OECMAKE_append = " \
     -DRPMB_EMU=0 \

--- a/meta-ledge-sw/recipes-security/optee/optee-os_%.bbappend
+++ b/meta-ledge-sw/recipes-security/optee/optee-os_%.bbappend
@@ -1,9 +1,11 @@
 
-# 3.14
-PV="3.14.0+git${SRCPV}"
-SRCREV_ledgecommon = "d21befa5e53eae9db469eba1685f5aa5c6f92c2f"
+# 3.16
+PV="3.16.0+git${SRCPV}"
+SRCREV_ledgecommon = "d0b742d1564834dac903f906168d7357063d5459"
 
 COMPATIBLE_MACHINE = "(ledge-qemuarm64|ledge-qemuarm)"
+
+DEPENDS_append += "python3-cryptography-native "
 
 SRC_URI_remove = " \
     file://0001-libutils-provide-empty-__getauxval-implementation.patch \

--- a/meta-ledge-sw/recipes-security/optee/optee-test_%.bbappend
+++ b/meta-ledge-sw/recipes-security/optee/optee-test_%.bbappend
@@ -1,11 +1,13 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
-# 3.14
+# 3.16
 SRC_URI = "git://github.com/OP-TEE/optee_test.git"
 
-PV="3.14.0+git${SRCPV}"
-SRCREV_ledgecommon = "f2eb88affbb7f028561b4fd5cbd049d5d704f741"
+PV="3.16.0+git${SRCPV}"
+SRCREV_ledgecommon = "1cf0e6d2bdd1145370033d4e182634458528579d"
 
 COMPATIBLE_MACHINE = "(ledge-qemuarm64|ledge-qemuarm)"
+
+DEPENDS_append += "python3-cryptography-native "
 
 EXTRA_OEMAKE_append_armv7a = " COMPILE_NS_USER=32"
 EXTRA_OEMAKE_append_armv7e = " COMPILE_NS_USER=32"


### PR DESCRIPTION
My local rpmb dev_id +1 hack no longer works, as rpmb device jumps around from one boot to the next. So bump to v3.16 to match meta-ts and provide Jeromes patches to optee-client.

I also tested xtest -t pkcs11 and that now runs sucessfully.