### PR TITLE
Add --rpmb-cid argument to tee-supplicant

### DIFF
--- a/meta-ledge-sw/recipes-ledge/images/files/init.cryptfs
+++ b/meta-ledge-sw/recipes-ledge/images/files/init.cryptfs
@@ -23,7 +23,16 @@ trap atexit EXIT
 
 /usr/sbin/rngd
 modprobe tpm_tis
-tee-supplicant &
+rpmb_cid () {
+  for f in /sys/class/mmc_host/mmc*/mmc*\:*/cid; do
+    [ "$CID" ] && { echo $0: WARNING: multiple eMMC devices found! >&2; return ; }
+    # POSIX shells don't expand globbing patterns that match no file
+    [ -e $f ] || return
+    CID=$(cat $f)
+  done
+  [ "$CID" ] && echo --rpmb-cid $CID
+}
+tee-supplicant $(rpmb-cid)&
 SUPP_PID=$!
 modprobe tpm_ftpm_tee
 

--- a/meta-ledge-sw/recipes-ledge/images/files/init.cryptfs
+++ b/meta-ledge-sw/recipes-ledge/images/files/init.cryptfs
@@ -13,7 +13,7 @@
 ARG_MNT_TARGET=$1
 ARG_ROOT=$2
 
-function atexit {
+atexit () {
 	# Do not leave tee-supplicant running. The rootfs init (systemd) will
 	# take care of starting it to its taste.
 	[ "$SUPP_PID" ] && kill $SUPP_PID

--- a/meta-ledge-sw/recipes-security/optee/optee-client/create-tee-supplicant-env
+++ b/meta-ledge-sw/recipes-security/optee/optee-client/create-tee-supplicant-env
@@ -1,0 +1,19 @@
+#!/bin/sh
+#
+# Create a systemd environment file for tee-supplicant
+# $1 is the path to the file to be generated.
+# At the moment this figures out the --rpmb-cid parameter to be given to
+# tee-supplicant, indicating which eMMC device OP-TEE should use for RPMB
+# storage.
+# No file is generated if no device is found (not an error) or if multiple
+# eMMCs are found (which is an error).
+
+[ "$1" ] || { echo Usage: $0 FILE >&2; exit 1; }
+
+for f in /sys/class/mmc_host/mmc*/mmc*\:*/cid; do
+  [ "$CID" ] && { echo $0: Multiple eMMC devices found, not chosing one automatically >&2; exit 2; }
+  # POSIX shells don't expand globbing patterns that match no file
+  [ -e $f ] || exit 0
+  CID=$(cat $f)
+done
+[ "$CID" ] && echo RPMB_CID="--rpmb-cid $CID" >$1

--- a/meta-ledge-sw/recipes-security/optee/optee-client_%.bbappend
+++ b/meta-ledge-sw/recipes-security/optee/optee-client_%.bbappend
@@ -15,10 +15,16 @@ file://0001-libckteec-add-support-for-ECDH-derive.patch \
 	file://0004-tee-supplicant-rpmb-introduce-readn-wrapper-to-the-r.patch \
 	file://0005-tee-supplicant-rpmb-read-CID-in-one-go.patch \
 	file://0006-tee-supplicant-add-rpmb-cid-command-line-option.patch \
+	file://create-tee-supplicant-env \
 	"
 
 EXTRA_OECMAKE_append = " \
     -DRPMB_EMU=0 \
 "
 
-
+do_install_append() {
+	install -D -p -m0755 ${WORKDIR}/create-tee-supplicant-env ${D}${sbindir}/create-tee-supplicant-env
+	sed -i "s|^ExecStart=.*$|EnvironmentFile=-@localstatedir@/run/tee-supplicant.env\nExecStartPre=@sbindir@/create-tee-supplicant-env @localstatedir@/run/tee-supplicant.env\nExecStart=@sbindir@/tee-supplicant $RPMB_CID $OPTARGS|" ${D}${systemd_system_unitdir}/tee-supplicant.service
+	sed -i -e s:@sbindir@:${sbindir}:g \
+	       -e s:@localstatedir@:${localstatedir}:g ${D}${systemd_system_unitdir}/tee-supplicant.service
+}


### PR DESCRIPTION
Two updates to `meta-ledge-sw/recipes-ledge/images/files/init.cryptfs`:
- Pass the ID of the eMMC to `tee-supplicant`
- A minor syntax fix