### PR TITLE
linux: dtb: rock-pi: reserve memory used by optee

### DIFF
--- a/meta-ledge-sw/recipes-kernel/linux/linux-ledge/0005-add-optee-reserve-memory.patch
+++ b/meta-ledge-sw/recipes-kernel/linux/linux-ledge/0005-add-optee-reserve-memory.patch
@@ -1,0 +1,36 @@
+From cb88f87db03cf416d140b70e37267dde49d0e8d0 Mon Sep 17 00:00:00 2001
+From: Maxim Uvarov <maxim.uvarov@linaro.org>
+Date: Mon, 4 Apr 2022 14:13:50 +0100
+Subject: [PATCH] add optee reserve memory
+
+Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>
+---
+ arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
+index 165a56a7b5f7..fe68044f5cc5 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3399-rock-pi-4.dtsi
+@@ -23,6 +23,18 @@
+         };
+     };
+ 
++    reserved-memory {
++            #address-cells = <2>;
++            #size-cells = <2>;
++            ranges;
++
++            optee@0x30000000 {
++                    reg = <0x0 0x30000000 0x0 0x2400000>;
++                    no-map;
++            };
++    };
++
++
+ 	chosen {
+ 		stdout-path = "serial2:1500000n8";
+ 	};
+-- 
+2.17.1
+

--- a/meta-ledge-sw/recipes-kernel/linux/linux-ledge_mainline.bb
+++ b/meta-ledge-sw/recipes-kernel/linux/linux-ledge_mainline.bb
@@ -29,6 +29,7 @@ SRC_URI += " \
     file://0002-KERNEL-stm32mp157-dts-add-ftpm-support.patch \
     file://0003-rk3399-rock-pi-4.dtsi-enable-imx219-isp.patch \
     file://0004-rk3399-rock-pi-4.dtsi-add-optee.patch \
+    file://0005-add-optee-reserve-memory.patch \
 "
 
 PV = "mainline-5.15"


### PR DESCRIPTION
u-boot optee has this memory reserver for optee needs.
For some reason the u-boot dtb entry is not propagated to
linux. Without that change the Rock Pi board can
randomly crash. Plan is to fix linux dtb first and later
debug uboot/optee dtb injection for the secure memory
reservation.

Signed-off-by: Maxim Uvarov <maxim.uvarov@linaro.org>