### PR TITLE
optee-client: do not run tee-supplicant as root

### DIFF
--- a/meta-ledge-sw/recipes-samples/images/ledge-minimal.bb
+++ b/meta-ledge-sw/recipes-samples/images/ledge-minimal.bb
@@ -16,5 +16,5 @@ CORE_IMAGE_BASE_INSTALL += " \
 EXTRA_USERS_PARAMS = "\
     useradd -P ledge ledge; \
     groupadd wheel; \
-    usermod -a -G sudo,wheel,adm ledge; \
+    usermod -a -G sudo,wheel,adm${@bb.utils.contains("MACHINE_FEATURES", "optee", ",teeclnt", "", d)} ledge; \
     "

--- a/meta-ledge-sw/recipes-security/optee/optee-client/optee-udev.rules
+++ b/meta-ledge-sw/recipes-security/optee/optee-client/optee-udev.rules
@@ -1,0 +1,2 @@
+KERNEL=="tee[0-9]*", MODE="0660", OWNER="root", GROUP="teeclnt"
+KERNEL=="teepriv[0-9]*", MODE="0660", OWNER="root", GROUP="tee"


### PR DESCRIPTION
Due to device and filesystem permissions, tee-supplicant and TEE
applications currently have to run as root. This is less than optimal.
Introduce groups 'tee' and 'teeclnt' for tee-supplicant and TEE
applications to use, respectively, as well as the 'tee' user (a member
of 'tee' the group) to run tee-supplicant.
- The new user and groups are created in optee-client_%.bbappend by
inheriting the useradd bbclass
- ledge-minimal.bb is updated to add user 'ledge' to the 'teeclnt'
group for convenience (when OP-TEE is enabled)
- Permissions on device nodes /dev/teepriv0 and /dev/tee0 are set via
udev rules, added in optee-client_%.bbappend
- The systemd startup script for tee-supplicant is updated to run as
tee:tee.
Tested on the qemuarm64-secureboot image.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>