### PR TITLE
optee-client: add teeclnt group for TEE client applications

### DIFF
--- a/meta-ledge-sw/recipes-samples/images/ledge-minimal.bb
+++ b/meta-ledge-sw/recipes-samples/images/ledge-minimal.bb
@@ -16,5 +16,5 @@ CORE_IMAGE_BASE_INSTALL += " \
 EXTRA_USERS_PARAMS = "\
     useradd -P ledge ledge; \
     groupadd wheel; \
-    usermod -a -G sudo,wheel,adm ledge; \
+    usermod -a -G sudo,wheel,adm${@bb.utils.contains("MACHINE_FEATURES", "optee", ",teeclnt", "", d)} ledge; \
     "

--- a/meta-ledge-sw/recipes-security/optee/optee-client/optee-udev.rules
+++ b/meta-ledge-sw/recipes-security/optee/optee-client/optee-udev.rules
@@ -1,0 +1,1 @@
+KERNEL=="tee[0-9]*", MODE="0660", OWNER="root", GROUP="teeclnt"

--- a/meta-ledge-sw/recipes-security/optee/optee-client_%.bbappend
+++ b/meta-ledge-sw/recipes-security/optee/optee-client_%.bbappend
@@ -16,6 +16,7 @@ file://0001-libckteec-add-support-for-ECDH-derive.patch \
 	file://0005-tee-supplicant-rpmb-read-CID-in-one-go.patch \
 	file://0006-tee-supplicant-add-rpmb-cid-command-line-option.patch \
 	file://create-tee-supplicant-env \
+	file://optee-udev.rules \
 	"
 
 EXTRA_OECMAKE_append = " \
@@ -27,4 +28,10 @@ do_install_append() {
 	sed -i "s|^ExecStart=.*$|EnvironmentFile=-@localstatedir@/run/tee-supplicant.env\nExecStartPre=@sbindir@/create-tee-supplicant-env @localstatedir@/run/tee-supplicant.env\nExecStart=@sbindir@/tee-supplicant $RPMB_CID $OPTARGS|" ${D}${systemd_system_unitdir}/tee-supplicant.service
 	sed -i -e s:@sbindir@:${sbindir}:g \
 	       -e s:@localstatedir@:${localstatedir}:g ${D}${systemd_system_unitdir}/tee-supplicant.service
+	install -d ${D}${sysconfdir}/udev/rules.d
+	install -m 0644 ${WORKDIR}/optee-udev.rules ${D}${sysconfdir}/udev/rules.d/optee.rules
 }
+
+inherit useradd
+USERADD_PACKAGES = "${PN}"
+GROUPADD_PARAM_${PN} = "--system teeclnt"


### PR DESCRIPTION
Due /dev/tee0 permissions, TEE applications currently have to run as root.
Introduce the teeclnt group so that application do not need full root
priviledges to access the TEE.
- the group is created by optee-client_%.bbappend
- ledge-minimal.bb is updated to add user 'ledge' to the 'teeclnt' group
for convenience (when OP-TEE is enabled)
- Permissions on device /dev/tee0 are set via udev rules, added to
optee-client_%.bbappend

Note that tee-supplicant is still run as root for simplicity and because
it seems there is not much security to gain from running it as a normal
user. It would still need CAP_SYS_RAWIO to access RPMB which is quite a
powerful capability already, and running as non-root introduces some
complexity (notably related to setting permissions on /dev/teepriv0 and
the startup of tee-supplicant, i.e., a dependency between a udev rule and
the tee-supplicant systemd service).

Tested on the qemuarm64-secureboot image.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>