### PR TITLE
optee: fix detection of RPMB device (--rpmb-cid)

### DIFF
--- a/meta-ledge-sw/recipes-ledge/images/files/init.cryptfs
+++ b/meta-ledge-sw/recipes-ledge/images/files/init.cryptfs
@@ -25,9 +25,12 @@ trap atexit EXIT
 modprobe tpm_tis
 rpmb_cid () {
   for f in /sys/class/mmc_host/mmc*/mmc*\:*/cid; do
-    [ "$CID" ] && { echo $0: WARNING: multiple eMMC devices found! >&2; return ; }
     # POSIX shells don't expand globbing patterns that match no file
     [ -e $f ] || return
+    devtype=$(echo $f | sed 's/cid/type/')
+    [ ! -e $devtype ] && continue
+    [ "$(cat $devtype)" != "MMC" ] && continue
+    [ "$CID" ] && { echo $0: WARNING: multiple eMMC devices found! >&2; return ; }
     CID=$(cat $f)
   done
   [ "$CID" ] && echo --rpmb-cid $CID

--- a/meta-ledge-sw/recipes-security/optee/optee-client/create-tee-supplicant-env
+++ b/meta-ledge-sw/recipes-security/optee/optee-client/create-tee-supplicant-env
@@ -11,9 +11,12 @@
 [ "$1" ] || { echo Usage: $0 FILE >&2; exit 1; }
 
 for f in /sys/class/mmc_host/mmc*/mmc*\:*/cid; do
-  [ "$CID" ] && { echo $0: Multiple eMMC devices found, not chosing one automatically >&2; exit 2; }
   # POSIX shells don't expand globbing patterns that match no file
   [ -e $f ] || exit 0
+  devtype=$(echo $f | sed 's/cid/type/')
+  [ ! -e $devtype ] && continue
+  [ "$(cat $devtype)" != "MMC" ] && continue
+  [ "$CID" ] && { echo $0: Multiple eMMC devices found, not chosing one automatically >&2; exit 2; }
   CID=$(cat $f)
 done
 [ "$CID" ] && echo RPMB_CID="--rpmb-cid $CID" >$1

--- a/meta-ledge-sw/recipes-security/optee/optee-client_%.bbappend
+++ b/meta-ledge-sw/recipes-security/optee/optee-client_%.bbappend
@@ -24,7 +24,7 @@ EXTRA_OECMAKE_append = " \
 
 do_install_append() {
 	install -D -p -m0755 ${WORKDIR}/create-tee-supplicant-env ${D}${sbindir}/create-tee-supplicant-env
-	sed -i "s|^ExecStart=.*$|EnvironmentFile=-@localstatedir@/run/tee-supplicant.env\nExecStartPre=@sbindir@/create-tee-supplicant-env @localstatedir@/run/tee-supplicant.env\nExecStart=@sbindir@/tee-supplicant $RPMB_CID $OPTARGS|" ${D}${systemd_system_unitdir}/tee-supplicant.service
+	sed -i 's|^ExecStart=.*$|EnvironmentFile=-@localstatedir@/run/tee-supplicant.env\nExecStartPre=@sbindir@/create-tee-supplicant-env @localstatedir@/run/tee-supplicant.env\nExecStart=@sbindir@/tee-supplicant $RPMB_CID $OPTARGS|' ${D}${systemd_system_unitdir}/tee-supplicant.service
 	sed -i -e s:@sbindir@:${sbindir}:g \
 	       -e s:@localstatedir@:${localstatedir}:g ${D}${systemd_system_unitdir}/tee-supplicant.service
 }


### PR DESCRIPTION
SD cards are wrongly detected as MMC by the scripts used to pass the
--rpmb-cid option to tee-supplicant. Use the 'type' entry in sysfs to
make sure we have indeed a (e)MMC and therefore a RPMB partition.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>