### PR TITLE
optee: init.cryptfs: one more RPMB fix

### DIFF
--- a/meta-ledge-sw/recipes-ledge/images/files/init.cryptfs
+++ b/meta-ledge-sw/recipes-ledge/images/files/init.cryptfs
@@ -35,7 +35,7 @@ rpmb_cid () {
   done
   [ "$CID" ] && echo --rpmb-cid $CID
 }
-tee-supplicant $(rpmb-cid)&
+tee-supplicant $(rpmb_cid)&
 SUPP_PID=$!
 modprobe tpm_ftpm_tee
 


### PR DESCRIPTION
Fix a typo in init.cryptfs (function name is rpmb_cid not rpmb-cid).

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>