### PR TITLE
linux-ledge_mainline.bb: use kernel 5.15.34

### DIFF
--- a/meta-ledge-sw/recipes-kernel/linux/linux-ledge_mainline.bb
+++ b/meta-ledge-sw/recipes-kernel/linux/linux-ledge_mainline.bb
@@ -11,11 +11,11 @@ include linux-ledge-sign.inc
 
 PR = "r4.ledge"
 
-LEDGE_KVERSION = "5.15"
+LEDGE_KVERSION = "5.15.34"
 
 # Stable kernel URL
 SRC_URI = "https://cdn.kernel.org/pub/linux/kernel/v5.x/linux-${LEDGE_KVERSION}.tar.xz;name=kernel"
-SRC_URI[kernel.sha256sum] = "57b2cf6991910e3b67a1b3490022e8a0674b6965c74c12da1e99d138d1991ee8"
+SRC_URI[kernel.sha256sum] = "a7514685392f0f89b337fa252a10a004c6a97d23e8d1126059c8e373398fdb69"
 
 # force SOURCE_DATE_EPOCH for build reproductible
 # SOURCE_DATE_EPOCH = "1557103378"


### PR DESCRIPTION
Update kernel to 5.15.34. Fixes the following OP-TEE related kernel Oops
on RockPi4 boards (RPMB storage test):
```
 # xtest regression_6018
 [...]
 reading 0
 [ 1997.259928] ------------[ cut here ]------------
 [ 1997.260389] kernel BUG at drivers/mmc/host/sdhci.c:774!
 [ 1997.260877] Internal error: Oops - BUG: 0 [#1] PREEMPT SMP
 [ 1997.261387] Modules linked in: bnep(E) overlay(E) btsdio(E) brcmfmac(E) snd_soc_hdmi_codec(E) dw_hdmi_i2s_audio(E) dw_hdmi_cec(E) rockchipdrm(E) hantro_vpu(CE) analogix_dp(E) brcmutil(E) dw_mipi_dsi(E) dw_hdmi(E) dwmac_rk(E) cec(E) v4l2_h264(E) drm_kms_helper(E) videobuf2_vmalloc(E) v4l2_mem2mem(E) stmmac_platform(E) hci_uart(E) videobuf2_dma_contig(E) stmmac(E) crct10dif_ce(E) ghash_ce(E) btqca(E) rockchip_saradc(E) phy_rockchip_pcie(E) videobuf2_memops(E) snd_soc_rockchip_i2s(E) snd_soc_rockchip_pcm(E) btbcm(E) videobuf2_v4l2(E) snd_soc_simple_card(E) videobuf2_common(E) snd_soc_simple_card_utils(E) pcs_xpcs(E) industrialio_triggered_buffer(E) kfifo_buf(E) panfrost(E) gpu_sched(E) rtc_rk808(E) btintel(E) rockchip_thermal(E) pcie_rockchip_host(E) efi_pstore(E) drm(E) sch_fq_codel(E) fuse(E) ipv6(E) tpm_ftpm_tee(E) tpm_tis(E) tpm_tis_core(E)
 [ 1997.268277] CPU: 1 PID: 242 Comm: kworker/1:1H Tainted: G         C  E     5.15.0 #1
 [ 1997.268979] Hardware name: Unknown Unknown Product/Unknown Product, BIOS 2022.04 04/01/2022
 [ 1997.269729] Workqueue: kblockd blk_mq_run_work_fn
 [ 1997.270177] pstate: 200000c5 (nzCv daIF -PAN -UAO -TCO -DIT -SSBS BTYPE=--)
 [ 1997.270809] pc : sdhci_send_command+0xc0c/0xe5c
 [ 1997.271230] lr : sdhci_send_command+0x634/0xe5c
 [ 1997.271652] sp : ffff80001273b830
 [ 1997.271956] x29: ffff80001273b830 x28: ffff80001273bd48 x27: 00000000046a0000
 [ 1997.272613] x26: ffff0000010a9e00 x25: ffff800012685000 x24: 0000000001676000
 [ 1997.273248] x23: 0000000000000000 x22: ffff80001273ba30 x21: ffff80001273ba50
 [ 1997.273883] x20: ffff80001273bb18 x19: ffff0000005b3580 x18: 0000000000000002
 [ 1997.274518] x17: 0000000000000000 x16: 0000000000000000 x15: 0000000000000021
 [ 1997.275153] x14: 00000000000003de x13: 0000000000000001 x12: 0000000000000000
 [ 1997.275788] x11: 0000000000000001 x10: 0000000000000ac0 x9 : ffff80001273b610
 [ 1997.276423] x8 : ffff0000010aa920 x7 : ffff0000f57ef3c0 x6 : ffff000000ec9708
 [ 1997.277057] x5 : 0000000000010200 x4 : 0000000000000000 x3 : 0000000000000000
 [ 1997.277692] x2 : 0000000000000000 x1 : 000000000000c097 x0 : ffff800012685200
 [ 1997.278326] Call trace:
 [ 1997.278547]  sdhci_send_command+0xc0c/0xe5c
 [ 1997.278922]  sdhci_send_command_retry+0x40/0x124
 [ 1997.279334]  sdhci_request+0x74/0xcc
 [ 1997.279655]  __mmc_start_request+0x68/0x140
 [ 1997.280030]  mmc_start_request+0x98/0xc0
 [ 1997.280381]  mmc_wait_for_req+0x74/0x104
 [ 1997.280732]  __mmc_blk_ioctl_cmd+0x148/0x484
 [ 1997.281115]  mmc_blk_mq_issue_rq+0x444/0xa60
 [ 1997.281498]  mmc_mq_queue_rq+0x120/0x2bc
 [ 1997.281851]  blk_mq_dispatch_rq_list+0x118/0x800
 [ 1997.282264]  __blk_mq_sched_dispatch_requests+0xb4/0x170
 [ 1997.282737]  blk_mq_sched_dispatch_requests+0x3c/0x80
 [ 1997.283186]  __blk_mq_run_hw_queue+0x54/0x90
 [ 1997.283568]  blk_mq_run_work_fn+0x24/0x30
 [ 1997.283926]  process_one_work+0x1d0/0x354
 [ 1997.284287]  worker_thread+0x13c/0x470
 [ 1997.284623]  kthread+0x154/0x160
 [ 1997.284915]  ret_from_fork+0x10/0x20
 [ 1997.285240] Code: 52800501 d63f0040 12001c16 17fffea3 (d4210000)
 [ 1997.285781] ---[ end trace ee366d18023e571c ]---
 [ 1997.286191] note: kworker/1:1H[242] exited with preempt_count 2
 [ 1997.286936] ------------[ cut here ]------------
 [ 1997.287356] WARNING: CPU: 1 PID: 0 at kernel/rcu/tree.c:613 rcu_eqs_enter.constprop.0+0x7c/0x84
 [ 1997.288137] Modules linked in: bnep(E) overlay(E) btsdio(E) brcmfmac(E) snd_soc_hdmi_codec(E) dw_hdmi_i2s_audio(E) dw_hdmi_cec(E) rockchipdrm(E) hantro_vpu(CE) analogix_dp(E) brcmutil(E) dw_mipi_dsi(E) dw_hdmi(E) dwmac_rk(E) cec(E) v4l2_h264(E) drm_kms_helper(E) videobuf2_vmalloc(E) v4l2_mem2mem(E) stmmac_platform(E) hci_uart(E) videobuf2_dma_contig(E) stmmac(E) crct10dif_ce(E) ghash_ce(E) btqca(E) rockchip_saradc(E) phy_rockchip_pcie(E) videobuf2_memops(E) snd_soc_rockchip_i2s(E) snd_soc_rockchip_pcm(E) btbcm(E) videobuf2_v4l2(E) snd_soc_simple_card(E) videobuf2_common(E) snd_soc_simple_card_utils(E) pcs_xpcs(E) industrialio_triggered_buffer(E) kfifo_buf(E) panfrost(E) gpu_sched(E) rtc_rk808(E) btintel(E) rockchip_thermal(E) pcie_rockchip_host(E) efi_pstore(E) drm(E) sch_fq_codel(E) fuse(E) ipv6(E) tpm_ftpm_tee(E) tpm_tis(E) tpm_tis_core(E)
 [ 1997.294782] CPU: 1 PID: 0 Comm: swapper/1 Tainted: G      D  C  E     5.15.0 #1
 [ 1997.295439] Hardware name: Unknown Unknown Product/Unknown Product, BIOS 2022.04 04/01/2022
 [ 1997.296181] pstate: 200003c5 (nzCv DAIF -PAN -UAO -TCO -DIT -SSBS BTYPE=--)
 [ 1997.296804] pc : rcu_eqs_enter.constprop.0+0x7c/0x84
 [ 1997.297261] lr : rcu_idle_enter+0x14/0x20
 [ 1997.297626] sp : ffff8000100e3d60
 [ 1997.297925] x29: ffff8000100e3d60 x28: 0000000000000000 x27: 0000000000000000
 [ 1997.298567] x26: 0000000000000000 x25: 0000000000000018 x24: 000001d10793d4f7
 [ 1997.299209] x23: 0000000000000000 x22: ffff000002691080 x21: ffff0000f57ee1c0
 [ 1997.299851] x20: 0000000000000000 x19: ffff0000f57f00c0 x18: 000000000000000e
 [ 1997.300491] x17: 0000000000000001 x16: 0000000000000019 x15: 0000000464005a97
```
Note: the test is *extremely* slow to complete, but it passes ultimately.
The speed issue will be investigated separately.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>