### PR TITLE
Rockpi4 boot and halt fixes

### DIFF
--- a/meta-ledge-sw/recipes-ledge/images/files/init.cryptfs
+++ b/meta-ledge-sw/recipes-ledge/images/files/init.cryptfs
@@ -40,7 +40,6 @@ cryptfs_create_enc_rootfs() {
 	if [ -z "${ROOT_BLK}" ]; then
 		echo "No rootfs with label rootfs check you /proc/cmdline:"
 		cat /proc/cmdline
-		sleep 120
 		/sbin/reboot
 		return 1
 	fi
@@ -92,7 +91,6 @@ if [ $? -ne 0 ]; then
 	if [ -z "${ROOT_BLK}" ]; then
 		echo "No blk dev matching root=UUID=${uuid} check your /proc/cmdline:"
 		cat /proc/cmdline
-		sleep 120
 		/sbin/reboot
 		exit 1
 	fi

--- a/meta-ledge-sw/recipes-ledge/images/files/init.cryptfs
+++ b/meta-ledge-sw/recipes-ledge/images/files/init.cryptfs
@@ -13,7 +13,14 @@
 ARG_MNT_TARGET=$1
 ARG_ROOT=$2
 
-/usr/sbin/rngd
+atexit () {
+  [ "$RNGD_PID" ] && kill $RNGD_PID
+}
+
+trap atexit EXIT
+
+/usr/sbin/rngd -f&
+RNGD_PID=$!
 modprobe tpm_tis
 rpmb_cid () {
   for f in /sys/class/mmc_host/mmc*/mmc*\:*/cid; do

--- a/meta-ledge-sw/recipes-security/optee/optee-client_%.bbappend
+++ b/meta-ledge-sw/recipes-security/optee/optee-client_%.bbappend
@@ -25,7 +25,7 @@ EXTRA_OECMAKE_append = " \
 
 do_install_append() {
 	install -D -p -m0755 ${WORKDIR}/create-tee-supplicant-env ${D}${sbindir}/create-tee-supplicant-env
-	sed -i 's|^ExecStart=.*$|EnvironmentFile=-@localstatedir@/run/tee-supplicant.env\nExecStartPre=@sbindir@/create-tee-supplicant-env @localstatedir@/run/tee-supplicant.env\nExecStart=@sbindir@/tee-supplicant $RPMB_CID $OPTARGS|' ${D}${systemd_system_unitdir}/tee-supplicant.service
+	sed -i 's|^ExecStart=.*$|EnvironmentFile=-@localstatedir@/run/tee-supplicant.env\nExecStartPre=@sbindir@/create-tee-supplicant-env @localstatedir@/run/tee-supplicant.env\nExecStart=@sbindir@/tee-supplicant $RPMB_CID $OPTARGS\nExecStop=-/sbin/modprobe -r tpm_ftpm_tee|' ${D}${systemd_system_unitdir}/tee-supplicant.service
 	sed -i -e s:@sbindir@:${sbindir}:g \
 	       -e s:@localstatedir@:${localstatedir}:g ${D}${systemd_system_unitdir}/tee-supplicant.service
 	install -d ${D}${sysconfdir}/udev/rules.d


### PR DESCRIPTION
A few patches addressing boot and shutdown issues I met on RockPi 4.
- The changes to `init.cryptfs` do what I expect at least but I have no idea about possible bad consequences so please review.
- The change to `tee-supplicant` shutdown is such that `systemctl stop tee-supplicant ; systemctl start tee-supplicant` will leave `tpm_ftpm_tee` unloaded. I don't know if it's an issue though. 